### PR TITLE
Remove private repository release method

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,6 @@ brew:
   github:
     owner: allenai
     name: homebrew-beaker
-  download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
   homepage: "https://beaker.allenai.org"
   description: "Beaker command-line tool."
   test: |


### PR DESCRIPTION
In order to work, this method requires the environment variable `HOMEBREW_GITHUB_API_TOKEN` to be set.  Since this repository is now public, the default method is sufficient.