### PR TITLE
Update goreleaser with beakerbot info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,9 @@ brew:
   github:
     owner: allenai
     name: homebrew-beaker
+  commit_author:
+    name: beakerbot
+    email: 43896404+beakerbot@users.noreply.github.com
   homepage: "https://beaker.allenai.org"
   description: "Beaker command-line tool."
   test: |

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ else
 	$(eval ARCHIVE := goreleaser_Linux_x86_64.tar.gz)
 endif
 
-	curl -L https://github.com/goreleaser/goreleaser/releases/download/v0.80.1/$(ARCHIVE) | tar -xvz -C$(TEMP) goreleaser
+	curl -L https://github.com/goreleaser/goreleaser/releases/download/v0.89.0/$(ARCHIVE) | tar -xvz -C$(TEMP) goreleaser
 	$(TEMP)/goreleaser release --rm-dist
 	rm -rf $(TEMP)
 


### PR DESCRIPTION
This change updates the version of GoReleaser we use, and changes the agent used for published commits to `beakerbot`, our automation robot.