### PR TITLE
Add TaskStatusSpec to API types

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -96,3 +96,16 @@ type TaskPatchSpec struct {
 	// (optional) Whether the task should be canceled. Ignored if false.
 	Cancel bool `json:"cancel,omitempty"`
 }
+
+// TaskStatusSpec describes a change in a task's status.
+type TaskStatusSpec struct {
+	// (required) Status to record for the task.
+	Status TaskStatus `json:"status"`
+
+	// (optional) Human-readable message to provide context for the status.
+	Message *string `json:"message,omitempty"`
+
+	// (optional) Exit code of the task's process.
+	// It is recommended to provide when entering Succeeded and Failed states.
+	ExitCode *int `json:"exitCode,omitempty"`
+}


### PR DESCRIPTION
I'm open to the idea of making this part of the `PATCH` API on tasks, but I decided to make this separate since that `PATCH` API is something users would use to modify metadata on a task, and this is a more specific kind of modification that should really only be performed by things that are part of the system.

ExitCode is a pointer instead of an int literal because the zero value of an int is `0`, and that's also a valid exit code. This way, `nil` means `not provided`.