### PR TITLE
Update SetStatus API helper to v3

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ import (
 // We encode the version as a manually-assigned constant for now. This must be
 // updated with each material change to how a client makes requests, and is
 // assumed to be monotonically increasing.
-const version = "v20181017"
+const version = "v20181026"
 
 var idPattern = regexp.MustCompile(`^\w\w_[a-z0-9]{12}$`)
 

--- a/client/task.go
+++ b/client/task.go
@@ -93,10 +93,9 @@ func (h *TaskHandle) Stop(ctx context.Context) error {
 
 // SetStatus overrides a task's status.
 // TODO: Move this to an internal-only API. External clients should call Stop to cancel tasks.
-func (h *TaskHandle) SetStatus(ctx context.Context, status api.TaskStatus) error {
-	path := path.Join("/api/tasks", h.id, "status")
-	query := map[string]string{"status": string(status)}
-	resp, err := h.client.sendRequest(ctx, http.MethodPut, path, query, nil)
+func (h *TaskHandle) SetStatus(ctx context.Context, spec api.TaskStatusSpec) error {
+	path := path.Join("/api/v3/tasks", h.id, "status")
+	resp, err := h.client.sendRequest(ctx, http.MethodPut, path, nil, spec)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Updating the API helper for `SetStatus` so sidecars can send statuses with exit codes & messages