### PR TITLE
Communicate directly with FileHeap

### DIFF
--- a/api/dataset.go
+++ b/api/dataset.go
@@ -5,15 +5,25 @@ import (
 	"time"
 )
 
+// PackageReference is a reference to a FileHeap package.
+type PackageReference struct {
+	PackageAddress string `json:"packageAddress,omitempty"`
+	PackageID      string `json:"packageID,omitempty"`
+}
+
 // CreateDatasetResponse is a service response returned when a new dataset is
 // created. For now it's just the dataset ID, but may be expanded in the future.
 type CreateDatasetResponse struct {
+	PackageReference
+
 	ID string `json:"id"`
 }
 
 // Dataset is a file or collection of files. It may be the result of a task or
 // uploaded directly by a user.
 type Dataset struct {
+	PackageReference
+
 	// The unique ID of the dataset.
 	ID   string `json:"id"`
 	User User   `json:"user"`

--- a/client/client.go
+++ b/client/client.go
@@ -18,11 +18,10 @@ import (
 	"time"
 
 	"github.com/goware/urlx"
+	retryable "github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 
 	"github.com/allenai/beaker/api"
-
-	retryable "github.com/hashicorp/go-retryablehttp"
 )
 
 // We encode the version as a manually-assigned constant for now. This must be

--- a/client/dataset.go
+++ b/client/dataset.go
@@ -135,8 +135,8 @@ type FileIterator interface {
 func (h *DatasetHandle) Files(ctx context.Context, path string) (FileIterator, error) {
 	if h.pkg != nil {
 		return &packageFileIterator{
-			dataset:    h,
-			fhIterator: h.pkg.Files(ctx, path),
+			dataset:  h,
+			iterator: h.pkg.Files(ctx, path),
 		}, nil
 	}
 
@@ -168,12 +168,12 @@ var ErrDone = errors.New("no more items in iterator")
 
 // packageFileIterator is an iterator over files within a FileHeap package.
 type packageFileIterator struct {
-	dataset    *DatasetHandle
-	fhIterator *fileheap.FileIterator
+	dataset  *DatasetHandle
+	iterator *fileheap.FileIterator
 }
 
 func (i *packageFileIterator) Next() (*FileHandle, *FileInfo, error) {
-	ref, info, err := i.fhIterator.Next()
+	ref, info, err := i.iterator.Next()
 	if err == fileheap.ErrDone {
 		return nil, nil, ErrDone
 	}

--- a/client/dataset.go
+++ b/client/dataset.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/allenai/beaker/api"
 	fileheap "github.com/allenai/fileheap-client/client"
 	"github.com/pkg/errors"
+
+	"github.com/allenai/beaker/api"
 )
 
 // DatasetHandle provides operations on a dataset.

--- a/client/dataset.go
+++ b/client/dataset.go
@@ -6,9 +6,12 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/allenai/beaker/api"
 	fileheap "github.com/allenai/fileheap-client/client"
+	"github.com/pkg/errors"
 )
 
 // DatasetHandle provides operations on a dataset.
@@ -106,6 +109,7 @@ func (h *DatasetHandle) Get(ctx context.Context) (*api.Dataset, error) {
 }
 
 // Manifest retrieves a manifest for a dataset's contents.
+// Deprecated. Use Files() instead.
 func (h *DatasetHandle) Manifest(ctx context.Context) (*api.DatasetManifest, error) {
 	path := path.Join("/api/v3/datasets", h.id, "manifest")
 	resp, err := h.client.sendRequest(ctx, http.MethodGet, path, nil, nil)
@@ -119,6 +123,99 @@ func (h *DatasetHandle) Manifest(ctx context.Context) (*api.DatasetManifest, err
 		return nil, err
 	}
 	return &body, nil
+}
+
+// FileIterator is an iterator over files within a dataset.
+type FileIterator interface {
+	Next() (*FileHandle, *FileInfo, error)
+}
+
+// Files returns an iterator over all files in the dataset under the given path.
+func (h *DatasetHandle) Files(ctx context.Context, path string) (FileIterator, error) {
+	if h.pkg != nil {
+		return &packageFileIterator{
+			dataset:    h,
+			fhIterator: h.pkg.Files(ctx, path),
+		}, nil
+	}
+
+	manifest, err := h.Manifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifestFileIterator{
+		dataset: h,
+		files:   manifest.Files,
+	}, nil
+}
+
+// FileInfo describes a single file within a dataset.
+type FileInfo struct {
+	// Path of the file relative to its dataset root.
+	Path string `json:"path"`
+
+	// Size of the file in bytes.
+	Size int64 `json:"size"`
+
+	// Time at which the file was last updated.
+	Updated time.Time `json:"updated"`
+}
+
+// ErrDone indicates an iterator is expended.
+var ErrDone = errors.New("no more items in iterator")
+
+// packageFileIterator is an iterator over files within a FileHeap package.
+type packageFileIterator struct {
+	dataset    *DatasetHandle
+	fhIterator *fileheap.FileIterator
+}
+
+func (i *packageFileIterator) Next() (*FileHandle, *FileInfo, error) {
+	ref, info, err := i.fhIterator.Next()
+	if err == fileheap.ErrDone {
+		return nil, nil, ErrDone
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return &FileHandle{
+			dataset: i.dataset,
+			file:    info.Path,
+			fileRef: ref,
+		}, &FileInfo{
+			Path:    info.Path,
+			Size:    info.Size,
+			Updated: info.Updated,
+		}, nil
+}
+
+// manifestFileIterator is an iterator over files in a dataset manifest.
+type manifestFileIterator struct {
+	dataset *DatasetHandle
+	files   []api.DatasetFile
+	prefix  string
+}
+
+func (i *manifestFileIterator) Next() (*FileHandle, *FileInfo, error) {
+	for len(i.files) > 0 && !strings.HasPrefix(i.files[0].File, i.prefix) {
+		i.files = i.files[1:]
+	}
+	if len(i.files) == 0 {
+		return nil, nil, ErrDone
+	}
+
+	file := i.files[0]
+	i.files = i.files[1:]
+
+	return &FileHandle{
+			dataset: i.dataset,
+			file:    file.File,
+		}, &FileInfo{
+			Path:    file.File,
+			Size:    int64(file.Size),
+			Updated: file.TimeLastModified,
+		}, nil
 }
 
 // SetName sets a dataset's name.

--- a/client/dataset.go
+++ b/client/dataset.go
@@ -6,11 +6,8 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"strings"
-	"time"
 
 	fileheap "github.com/allenai/fileheap-client/client"
-	"github.com/pkg/errors"
 
 	"github.com/allenai/beaker/api"
 )
@@ -126,11 +123,6 @@ func (h *DatasetHandle) Manifest(ctx context.Context) (*api.DatasetManifest, err
 	return &body, nil
 }
 
-// FileIterator is an iterator over files within a dataset.
-type FileIterator interface {
-	Next() (*FileHandle, *FileInfo, error)
-}
-
 // Files returns an iterator over all files in the dataset under the given path.
 func (h *DatasetHandle) Files(ctx context.Context, path string) (FileIterator, error) {
 	if h.pkg != nil {
@@ -149,74 +141,6 @@ func (h *DatasetHandle) Files(ctx context.Context, path string) (FileIterator, e
 		dataset: h,
 		files:   manifest.Files,
 	}, nil
-}
-
-// FileInfo describes a single file within a dataset.
-type FileInfo struct {
-	// Path of the file relative to its dataset root.
-	Path string `json:"path"`
-
-	// Size of the file in bytes.
-	Size int64 `json:"size"`
-
-	// Time at which the file was last updated.
-	Updated time.Time `json:"updated"`
-}
-
-// ErrDone indicates an iterator is expended.
-var ErrDone = errors.New("no more items in iterator")
-
-// packageFileIterator is an iterator over files within a FileHeap package.
-type packageFileIterator struct {
-	dataset  *DatasetHandle
-	iterator *fileheap.FileIterator
-}
-
-func (i *packageFileIterator) Next() (*FileHandle, *FileInfo, error) {
-	ref, info, err := i.iterator.Next()
-	if err == fileheap.ErrDone {
-		return nil, nil, ErrDone
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-	return &FileHandle{
-			dataset: i.dataset,
-			file:    info.Path,
-			fileRef: ref,
-		}, &FileInfo{
-			Path:    info.Path,
-			Size:    info.Size,
-			Updated: info.Updated,
-		}, nil
-}
-
-// manifestFileIterator is an iterator over files in a dataset manifest.
-type manifestFileIterator struct {
-	dataset *DatasetHandle
-	files   []api.DatasetFile
-	prefix  string
-}
-
-func (i *manifestFileIterator) Next() (*FileHandle, *FileInfo, error) {
-	for len(i.files) > 0 && !strings.HasPrefix(i.files[0].File, i.prefix) {
-		i.files = i.files[1:]
-	}
-	if len(i.files) == 0 {
-		return nil, nil, ErrDone
-	}
-
-	file := i.files[0]
-	i.files = i.files[1:]
-
-	return &FileHandle{
-			dataset: i.dataset,
-			file:    file.File,
-		}, &FileInfo{
-			Path:    file.File,
-			Size:    int64(file.Size),
-			Updated: file.TimeLastModified,
-		}, nil
 }
 
 // SetName sets a dataset's name.

--- a/client/file.go
+++ b/client/file.go
@@ -135,7 +135,7 @@ func (h *FileHandle) Upload(ctx context.Context, source io.ReadSeeker) error {
 		}
 
 		// Ignore error; handle on close.
-		io.Copy(w, body)
+		_, _ = io.Copy(w, body)
 
 		return errors.WithStack(w.Close())
 	}

--- a/client/file.go
+++ b/client/file.go
@@ -144,9 +144,8 @@ func (h *FileHandle) Upload(ctx context.Context, source io.ReadSeeker) error {
 			return errors.WithStack(err)
 		}
 
-		if _, err = io.Copy(w, body); err != nil {
-			return errors.WithStack(err)
-		}
+		// Ignore error; handle on close.
+		_, _ = io.Copy(w, body)
 
 		return errors.WithStack(w.Close())
 	}

--- a/client/file.go
+++ b/client/file.go
@@ -94,7 +94,13 @@ func (h *FileHandle) DownloadTo(ctx context.Context, filePath string) error {
 
 	var written int64
 	for {
-		r, err := h.DownloadRange(ctx, written, -1)
+		var r io.ReadCloser
+		var err error
+		if written == 0 {
+			r, err = h.Download(ctx)
+		} else {
+			r, err = h.DownloadRange(ctx, written, -1)
+		}
 		if err != nil {
 			return err
 		}

--- a/client/file.go
+++ b/client/file.go
@@ -25,7 +25,11 @@ type FileHandle struct {
 // FileRef creates an actor for an existing file within a dataset.
 // This call doesn't perform any network operations.
 func (h *DatasetHandle) FileRef(filePath string) *FileHandle {
-	return &FileHandle{h, filePath, h.pkg.File(filePath)}
+	var fileRef *fileheap.FileRef
+	if h.pkg != nil {
+		fileRef = h.pkg.File(filePath)
+	}
+	return &FileHandle{h, filePath, fileRef}
 }
 
 // Download gets a file from a datastore.

--- a/client/file.go
+++ b/client/file.go
@@ -140,8 +140,9 @@ func (h *FileHandle) Upload(ctx context.Context, source io.ReadSeeker) error {
 			return errors.WithStack(err)
 		}
 
-		// Ignore error; handle on close.
-		_, _ = io.Copy(w, body)
+		if _, err = io.Copy(w, body); err != nil {
+			return errors.WithStack(err)
+		}
 
 		return errors.WithStack(w.Close())
 	}

--- a/client/file.go
+++ b/client/file.go
@@ -7,15 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 
 	"github.com/pkg/errors"
-
-	"github.com/allenai/beaker/api"
 )
 
 // FileHandle provides operations on a file within a dataset.
@@ -28,24 +24,6 @@ type FileHandle struct {
 // This call doesn't perform any network operations.
 func (h *DatasetHandle) FileRef(filePath string) *FileHandle {
 	return &FileHandle{h, filePath}
-}
-
-// PresignLink creates a pre-signed URL link to a file.
-// Deprecated. Use Upload and Download instead.
-func (h *FileHandle) PresignLink(ctx context.Context, forWrite bool) (*api.DatasetFileLink, error) {
-	path := path.Join("/api/v3/datasets", h.dataset.id, "links", h.file)
-	query := url.Values{"upload": {strconv.FormatBool(forWrite)}}
-	resp, err := h.dataset.client.sendRequest(ctx, http.MethodPost, path, query, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer safeClose(resp.Body)
-
-	var body api.DatasetFileLink
-	if err = parseResponse(resp, &body); err != nil {
-		return nil, err
-	}
-	return &body, nil
 }
 
 // Download gets a file from a datastore.

--- a/client/iterator.go
+++ b/client/iterator.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/allenai/beaker/api"
 	fileheap "github.com/allenai/fileheap-client/client"
 	"github.com/pkg/errors"
+
+	"github.com/allenai/beaker/api"
 )
 
 // FileIterator is an iterator over files within a dataset.

--- a/client/iterator.go
+++ b/client/iterator.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"strings"
+	"time"
+
+	"github.com/allenai/beaker/api"
+	fileheap "github.com/allenai/fileheap-client/client"
+	"github.com/pkg/errors"
+)
+
+// FileIterator is an iterator over files within a dataset.
+type FileIterator interface {
+	Next() (*FileHandle, *FileInfo, error)
+}
+
+// FileInfo describes a single file within a dataset.
+type FileInfo struct {
+	// Path of the file relative to its dataset root.
+	Path string `json:"path"`
+
+	// Size of the file in bytes.
+	Size int64 `json:"size"`
+
+	// Time at which the file was last updated.
+	Updated time.Time `json:"updated"`
+}
+
+// ErrDone indicates an iterator is expended.
+var ErrDone = errors.New("no more items in iterator")
+
+// packageFileIterator is an iterator over files within a FileHeap package.
+type packageFileIterator struct {
+	dataset  *DatasetHandle
+	iterator *fileheap.FileIterator
+}
+
+func (i *packageFileIterator) Next() (*FileHandle, *FileInfo, error) {
+	ref, info, err := i.iterator.Next()
+	if err == fileheap.ErrDone {
+		return nil, nil, ErrDone
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return &FileHandle{
+			dataset: i.dataset,
+			file:    info.Path,
+			fileRef: ref,
+		}, &FileInfo{
+			Path:    info.Path,
+			Size:    info.Size,
+			Updated: info.Updated,
+		}, nil
+}
+
+// manifestFileIterator is an iterator over files in a dataset manifest.
+type manifestFileIterator struct {
+	dataset *DatasetHandle
+	files   []api.DatasetFile
+	prefix  string
+}
+
+func (i *manifestFileIterator) Next() (*FileHandle, *FileInfo, error) {
+	for len(i.files) > 0 && !strings.HasPrefix(i.files[0].File, i.prefix) {
+		i.files = i.files[1:]
+	}
+	if len(i.files) == 0 {
+		return nil, nil, ErrDone
+	}
+
+	file := i.files[0]
+	i.files = i.files[1:]
+
+	return &FileHandle{
+			dataset: i.dataset,
+			file:    file.File,
+		}, &FileInfo{
+			Path:    file.File,
+			Size:    int64(file.Size),
+			Updated: file.TimeLastModified,
+		}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180108190415-b31f603f5e1e
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d // indirect
+	github.com/allenai/fileheap-client v0.0.0-20181206224701-024872243b71
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.6.2+incompatible // indirect
 	github.com/docker/docker v1.13.1

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/allenai/beaker
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180108190415-b31f603f5e1e
-	github.com/PuerkitoBio/purell v1.1.0 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.6.2+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -16,8 +16,8 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/pkg/errors v0.8.0
-	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d // indirect
-	golang.org/x/text v0.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,9 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d h1:erl94b7ppjVoRrDtWMtyVUja1gUuocNPQaS6hEcF+Q0=
+github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d/go.mod h1:Ebg+Xnqi/B8sOwwTeU5pAZvWk3kRuKHdujWPHcAOFMA=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.6.2+incompatible h1:4FI6af79dfCS/CYb+RRtkSHw3q1L/bnDjG1PcPZtQhM=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
@@ -32,8 +35,13 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181201002055-351d144fa1fc h1:a3CU5tJYVj92DY2LaA1kUkrsqD5/3mLDhx2NcNqyW+0=
+golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d h1:erl94b7ppjVoRrDtWMtyVUja1gUuocNPQaS6hEcF+Q0=
 github.com/allenai/fileheap-client v0.0.0-20181206011434-e72ab14bbd6d/go.mod h1:Ebg+Xnqi/B8sOwwTeU5pAZvWk3kRuKHdujWPHcAOFMA=
+github.com/allenai/fileheap-client v0.0.0-20181206213212-11420e1abb90 h1:+RvXjSCLt4pzxWey+skOyplUymzSIrQBi5Vlr9xdn0s=
+github.com/allenai/fileheap-client v0.0.0-20181206213212-11420e1abb90/go.mod h1:Ebg+Xnqi/B8sOwwTeU5pAZvWk3kRuKHdujWPHcAOFMA=
+github.com/allenai/fileheap-client v0.0.0-20181206224701-024872243b71 h1:E3Zh8Yxu1EO7h7jsVl9cWlf5woWkAvgHphxXaZ6mB2A=
+github.com/allenai/fileheap-client v0.0.0-20181206224701-024872243b71/go.mod h1:Ebg+Xnqi/B8sOwwTeU5pAZvWk3kRuKHdujWPHcAOFMA=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.6.2+incompatible h1:4FI6af79dfCS/CYb+RRtkSHw3q1L/bnDjG1PcPZtQhM=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
 - Remove `FileHandle.PresignLink`
 - Deprecate `DatasetHandle.Manifest`
 - Add `DatasetHandle.Files` (replaces `DatasetHandle.Manifest`)
 - Update `FileHandle` functions to communicate directly with FileHeap when possible.