### PR TITLE
Alias blueprint commands with image commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ must be installed to take full advantage of Beaker.
    ```bash
    beaker experiment run \
      --name wordcount-moby \
-     --blueprint examples/wordcount \
+     --image examples/wordcount \
      --source examples/moby:/input \
      --result-path /output
    ```

--- a/client/image.go
+++ b/client/image.go
@@ -12,7 +12,7 @@ import (
 	"github.com/allenai/beaker/api"
 )
 
-// ImageHandle provides operations on a image.
+// ImageHandle provides operations on an image.
 type ImageHandle struct {
 	client *Client
 	id     string
@@ -43,7 +43,7 @@ func (c *Client) CreateImage(
 	return &ImageHandle{client: c, id: body.ID}, nil
 }
 
-// Image gets a handle for a image by name or ID. The returned handle is
+// Image gets a handle for an image by name or ID. The returned handle is
 // guaranteed throughout its lifetime to refer to the same object, even if that
 // object is later renamed.
 func (c *Client) Image(ctx context.Context, reference string) (*ImageHandle, error) {
@@ -55,12 +55,12 @@ func (c *Client) Image(ctx context.Context, reference string) (*ImageHandle, err
 	return &ImageHandle{client: c, id: id}, nil
 }
 
-// ID returns a image's stable, unique ID.
+// ID returns an image's stable, unique ID.
 func (h *ImageHandle) ID() string {
 	return h.id
 }
 
-// Get retrieves a image's details.
+// Get retrieves an image's details.
 func (h *ImageHandle) Get(ctx context.Context) (*api.Image, error) {
 	uri := path.Join("/api/v3/images", h.id)
 	resp, err := h.client.sendRequest(ctx, http.MethodGet, uri, nil, nil)
@@ -76,7 +76,7 @@ func (h *ImageHandle) Get(ctx context.Context) (*api.Image, error) {
 	return &body, nil
 }
 
-// Repository returns information required to push a image's Docker image.
+// Repository returns information required to push an image's Docker image.
 func (h *ImageHandle) Repository(
 	ctx context.Context,
 	upload bool,
@@ -96,7 +96,7 @@ func (h *ImageHandle) Repository(
 	return &body, nil
 }
 
-// SetName sets a image's name.
+// SetName sets an image's name.
 func (h *ImageHandle) SetName(ctx context.Context, name string) error {
 	path := path.Join("/api/v3/images", h.id)
 	body := api.ImagePatchSpec{Name: &name}
@@ -108,7 +108,7 @@ func (h *ImageHandle) SetName(ctx context.Context, name string) error {
 	return errorFromResponse(resp)
 }
 
-// SetDescription sets a image's description.
+// SetDescription sets an image's description.
 func (h *ImageHandle) SetDescription(ctx context.Context, description string) error {
 	path := path.Join("/api/v3/images", h.id)
 	body := api.ImagePatchSpec{Description: &description}
@@ -150,24 +150,4 @@ func (h *ImageHandle) PatchPermissions(
 	}
 	defer safeClose(resp.Body)
 	return errorFromResponse(resp)
-}
-
-func (c *Client) SearchImages(
-	ctx context.Context,
-	searchOptions api.ImageSearchOptions,
-	page int,
-) ([]api.Image, error) {
-	query := url.Values{"page": {strconv.Itoa(page)}}
-	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/images/search", query, searchOptions)
-	if err != nil {
-		return nil, err
-	}
-	defer safeClose(resp.Body)
-
-	var body []api.Image
-	if err := parseResponse(resp, &body); err != nil {
-		return nil, err
-	}
-
-	return body, nil
 }

--- a/client/image.go
+++ b/client/image.go
@@ -12,18 +12,18 @@ import (
 	"github.com/allenai/beaker/api"
 )
 
-// BlueprintHandle provides operations on a blueprint.
-type BlueprintHandle struct {
+// ImageHandle provides operations on a image.
+type ImageHandle struct {
 	client *Client
 	id     string
 }
 
-// CreateBlueprint creates a new blueprint with an optional name.
-func (c *Client) CreateBlueprint(
+// CreateImage creates a new image with an optional name.
+func (c *Client) CreateImage(
 	ctx context.Context,
 	spec api.ImageSpec,
 	name string,
-) (*BlueprintHandle, error) {
+) (*ImageHandle, error) {
 	query := url.Values{}
 	if name != "" {
 		query.Set("name", name)
@@ -40,28 +40,28 @@ func (c *Client) CreateBlueprint(
 		return nil, err
 	}
 
-	return &BlueprintHandle{client: c, id: body.ID}, nil
+	return &ImageHandle{client: c, id: body.ID}, nil
 }
 
-// Blueprint gets a handle for a blueprint by name or ID. The returned handle is
+// Image gets a handle for a image by name or ID. The returned handle is
 // guaranteed throughout its lifetime to refer to the same object, even if that
 // object is later renamed.
-func (c *Client) Blueprint(ctx context.Context, reference string) (*BlueprintHandle, error) {
+func (c *Client) Image(ctx context.Context, reference string) (*ImageHandle, error) {
 	id, err := c.resolveRef(ctx, "/api/v3/blueprints", reference)
 	if err != nil {
-		return nil, errors.WithMessage(err, "could not resolve blueprint reference "+reference)
+		return nil, errors.WithMessage(err, "could not resolve image reference "+reference)
 	}
 
-	return &BlueprintHandle{client: c, id: id}, nil
+	return &ImageHandle{client: c, id: id}, nil
 }
 
-// ID returns a blueprint's stable, unique ID.
-func (h *BlueprintHandle) ID() string {
+// ID returns a image's stable, unique ID.
+func (h *ImageHandle) ID() string {
 	return h.id
 }
 
-// Get retrieves a blueprint's details.
-func (h *BlueprintHandle) Get(ctx context.Context) (*api.Image, error) {
+// Get retrieves a image's details.
+func (h *ImageHandle) Get(ctx context.Context) (*api.Image, error) {
 	uri := path.Join("/api/v3/blueprints", h.id)
 	resp, err := h.client.sendRequest(ctx, http.MethodGet, uri, nil, nil)
 	if err != nil {
@@ -76,8 +76,8 @@ func (h *BlueprintHandle) Get(ctx context.Context) (*api.Image, error) {
 	return &body, nil
 }
 
-// Repository returns information required to push a blueprint's Docker image.
-func (h *BlueprintHandle) Repository(
+// Repository returns information required to push a image's Docker image.
+func (h *ImageHandle) Repository(
 	ctx context.Context,
 	upload bool,
 ) (*api.ImageRepository, error) {
@@ -96,8 +96,8 @@ func (h *BlueprintHandle) Repository(
 	return &body, nil
 }
 
-// SetName sets a blueprint's name.
-func (h *BlueprintHandle) SetName(ctx context.Context, name string) error {
+// SetName sets a image's name.
+func (h *ImageHandle) SetName(ctx context.Context, name string) error {
 	path := path.Join("/api/v3/blueprints", h.id)
 	body := api.ImagePatchSpec{Name: &name}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
@@ -108,8 +108,8 @@ func (h *BlueprintHandle) SetName(ctx context.Context, name string) error {
 	return errorFromResponse(resp)
 }
 
-// SetDescription sets a blueprint's description.
-func (h *BlueprintHandle) SetDescription(ctx context.Context, description string) error {
+// SetDescription sets a image's description.
+func (h *ImageHandle) SetDescription(ctx context.Context, description string) error {
 	path := path.Join("/api/v3/blueprints", h.id)
 	body := api.ImagePatchSpec{Description: &description}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
@@ -120,9 +120,9 @@ func (h *BlueprintHandle) SetDescription(ctx context.Context, description string
 	return errorFromResponse(resp)
 }
 
-// Commit finalizes a blueprint, unblocking usage and locking it for further
-// writes. The blueprint is guaranteed to remain uncommitted on failure.
-func (h *BlueprintHandle) Commit(ctx context.Context) error {
+// Commit finalizes an image, unblocking usage and locking it for further
+// writes. The image is guaranteed to remain uncommitted on failure.
+func (h *ImageHandle) Commit(ctx context.Context) error {
 	path := path.Join("/api/v3/blueprints", h.id)
 	body := api.ImagePatchSpec{Commit: true}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
@@ -133,13 +133,13 @@ func (h *BlueprintHandle) Commit(ctx context.Context) error {
 	return errorFromResponse(resp)
 }
 
-// GetPermissions gets a summary of the user's permissions on the blueprint.
-func (h *BlueprintHandle) GetPermissions(ctx context.Context) (*api.PermissionSummary, error) {
+// GetPermissions gets a summary of the user's permissions on the image.
+func (h *ImageHandle) GetPermissions(ctx context.Context) (*api.PermissionSummary, error) {
 	return getPermissions(ctx, h.client, path.Join("/api/v3/blueprints", h.ID(), "auth"))
 }
 
-// PatchPermissions ammends a blueprint's permissions.
-func (h *BlueprintHandle) PatchPermissions(
+// PatchPermissions ammends an image's permissions.
+func (h *ImageHandle) PatchPermissions(
 	ctx context.Context,
 	permissionPatch api.PermissionPatch,
 ) error {
@@ -152,7 +152,7 @@ func (h *BlueprintHandle) PatchPermissions(
 	return errorFromResponse(resp)
 }
 
-func (c *Client) SearchBlueprints(
+func (c *Client) SearchImages(
 	ctx context.Context,
 	searchOptions api.ImageSearchOptions,
 	page int,

--- a/client/image.go
+++ b/client/image.go
@@ -29,7 +29,7 @@ func (c *Client) CreateImage(
 		query.Set("name", name)
 	}
 
-	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/blueprints", query, spec)
+	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/images", query, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (c *Client) CreateImage(
 // guaranteed throughout its lifetime to refer to the same object, even if that
 // object is later renamed.
 func (c *Client) Image(ctx context.Context, reference string) (*ImageHandle, error) {
-	id, err := c.resolveRef(ctx, "/api/v3/blueprints", reference)
+	id, err := c.resolveRef(ctx, "/api/v3/images", reference)
 	if err != nil {
 		return nil, errors.WithMessage(err, "could not resolve image reference "+reference)
 	}
@@ -62,7 +62,7 @@ func (h *ImageHandle) ID() string {
 
 // Get retrieves a image's details.
 func (h *ImageHandle) Get(ctx context.Context) (*api.Image, error) {
-	uri := path.Join("/api/v3/blueprints", h.id)
+	uri := path.Join("/api/v3/images", h.id)
 	resp, err := h.client.sendRequest(ctx, http.MethodGet, uri, nil, nil)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (h *ImageHandle) Repository(
 	ctx context.Context,
 	upload bool,
 ) (*api.ImageRepository, error) {
-	path := path.Join("/api/v3/blueprints", h.id, "repository")
+	path := path.Join("/api/v3/images", h.id, "repository")
 	query := url.Values{"upload": {strconv.FormatBool(upload)}}
 	resp, err := h.client.sendRequest(ctx, http.MethodPost, path, query, nil)
 	if err != nil {
@@ -98,7 +98,7 @@ func (h *ImageHandle) Repository(
 
 // SetName sets a image's name.
 func (h *ImageHandle) SetName(ctx context.Context, name string) error {
-	path := path.Join("/api/v3/blueprints", h.id)
+	path := path.Join("/api/v3/images", h.id)
 	body := api.ImagePatchSpec{Name: &name}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
 	if err != nil {
@@ -110,7 +110,7 @@ func (h *ImageHandle) SetName(ctx context.Context, name string) error {
 
 // SetDescription sets a image's description.
 func (h *ImageHandle) SetDescription(ctx context.Context, description string) error {
-	path := path.Join("/api/v3/blueprints", h.id)
+	path := path.Join("/api/v3/images", h.id)
 	body := api.ImagePatchSpec{Description: &description}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
 	if err != nil {
@@ -123,7 +123,7 @@ func (h *ImageHandle) SetDescription(ctx context.Context, description string) er
 // Commit finalizes an image, unblocking usage and locking it for further
 // writes. The image is guaranteed to remain uncommitted on failure.
 func (h *ImageHandle) Commit(ctx context.Context) error {
-	path := path.Join("/api/v3/blueprints", h.id)
+	path := path.Join("/api/v3/images", h.id)
 	body := api.ImagePatchSpec{Commit: true}
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, body)
 	if err != nil {
@@ -135,7 +135,7 @@ func (h *ImageHandle) Commit(ctx context.Context) error {
 
 // GetPermissions gets a summary of the user's permissions on the image.
 func (h *ImageHandle) GetPermissions(ctx context.Context) (*api.PermissionSummary, error) {
-	return getPermissions(ctx, h.client, path.Join("/api/v3/blueprints", h.ID(), "auth"))
+	return getPermissions(ctx, h.client, path.Join("/api/v3/images", h.ID(), "auth"))
 }
 
 // PatchPermissions ammends an image's permissions.
@@ -143,7 +143,7 @@ func (h *ImageHandle) PatchPermissions(
 	ctx context.Context,
 	permissionPatch api.PermissionPatch,
 ) error {
-	path := path.Join("/api/v3/blueprints", h.id, "auth")
+	path := path.Join("/api/v3/images", h.id, "auth")
 	resp, err := h.client.sendRequest(ctx, http.MethodPatch, path, nil, permissionPatch)
 	if err != nil {
 		return err
@@ -158,7 +158,7 @@ func (c *Client) SearchImages(
 	page int,
 ) ([]api.Image, error) {
 	query := url.Values{"page": {strconv.Itoa(page)}}
-	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/blueprints/search", query, searchOptions)
+	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/images/search", query, searchOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/beaker/blueprint/create.go
+++ b/cmd/beaker/blueprint/create.go
@@ -26,7 +26,7 @@ func newCreateCmd(
 	cmd.Arg("image", "Docker image ID").Required().StringVar(imageID)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		// TODO message reminding to switch to image commands
+		PrintBeakerDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err

--- a/cmd/beaker/blueprint/create.go
+++ b/cmd/beaker/blueprint/create.go
@@ -2,148 +2,36 @@ package blueprint
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 
-	"github.com/docker/docker/api/types"
-	docker "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/fatih/color"
-	"github.com/pkg/errors"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/allenai/beaker/api"
 	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/config"
 )
 
-// CreateOptions wraps options used to create a blueprint.
-type CreateOptions struct {
-	Description string
-	Name        string
-	Quiet       bool
-}
-
 func newCreateCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *blueprintOptions,
+	parentOpts *image.ImageOptions,
 	config *config.Config,
 ) {
-	opts := &CreateOptions{}
-	image := new(string)
+	opts := &image.CreateOptions{}
+	imageID := new(string)
 
 	cmd := parent.Command("create", "Create a new blueprint")
 	cmd.Flag("desc", "Assign a description to the blueprint").StringVar(&opts.Description)
 	cmd.Flag("name", "Assign a name to the blueprint").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created blueprint's ID").Short('q').BoolVar(&opts.Quiet)
-	cmd.Arg("image", "Docker image ID").Required().StringVar(image)
+	cmd.Arg("image", "Docker image ID").Required().StringVar(imageID)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		// TODO message reminding to switch to image commands
+		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}
-		_, err = Create(context.TODO(), os.Stdout, beaker, *image, opts)
+		_, err = image.Create(context.TODO(), os.Stdout, beaker, *imageID, opts)
 		return err
 	})
-}
-
-// Create creates a new blueprint and returns its ID.
-func Create(
-	ctx context.Context,
-	w io.Writer,
-	beaker *beaker.Client,
-	imageTag string,
-	opts *CreateOptions,
-) (string, error) {
-	if w == nil {
-		w = ioutil.Discard
-	}
-	if opts == nil {
-		opts = &CreateOptions{}
-	}
-
-	docker, err := docker.NewEnvClient()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create Docker client")
-	}
-
-	image, _, err := docker.ImageInspectWithRaw(ctx, imageTag)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	spec := api.ImageSpec{
-		Description: opts.Description,
-		ImageID:     image.ID,
-		ImageTag:    imageTag,
-	}
-	blueprint, err := beaker.CreateImage(ctx, spec, opts.Name)
-	if err != nil {
-		return "", err
-	}
-
-	if !opts.Quiet {
-		if opts.Name == "" {
-			fmt.Fprintf(w, "Pushing %s as %s ...\n", imageTag, color.BlueString(blueprint.ID()))
-		} else {
-			fmt.Fprintf(w, "Pushing %s as %s (%s)...\n", imageTag, color.BlueString(opts.Name), blueprint.ID())
-		}
-	}
-
-	repo, err := blueprint.Repository(ctx, true)
-	if err != nil {
-		return "", errors.WithMessage(err, "failed to retrieve credentials for remote repository")
-	}
-
-	// Tag the image to the remote repository.
-	if err := docker.ImageTag(ctx, imageTag, repo.ImageTag); err != nil {
-		return "", errors.Wrap(err, "failed to set remote image tag")
-	}
-	defer func() {
-		// We ignore the error here intentionally. Cleaning up is best-effort
-		// and we can't do anything to recover if this fails.
-		_, _ = docker.ImageRemove(ctx, repo.ImageTag, types.ImageRemoveOptions{})
-	}()
-
-	authConfig := types.AuthConfig{
-		ServerAddress: repo.Auth.ServerAddress,
-		Username:      repo.Auth.User,
-		Password:      repo.Auth.Password,
-	}
-	authJSON, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to encode remote repository auth")
-	}
-	authStr := base64.URLEncoding.EncodeToString(authJSON)
-
-	r, err := docker.ImagePush(ctx, repo.ImageTag, types.ImagePushOptions{RegistryAuth: authStr})
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	defer r.Close()
-
-	// Display push responses as the Docker CLI would. This also translates remote errors.
-	var stream io.Writer = os.Stdout
-	if opts.Quiet {
-		stream = ioutil.Discard
-	}
-	if err := jsonmessage.DisplayJSONMessagesStream(r, stream, 0, false, nil); err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	if err := blueprint.Commit(ctx); err != nil {
-		return "", errors.WithMessage(err, "failed to commit blueprint")
-	}
-
-	if opts.Quiet {
-		fmt.Fprintln(w, blueprint.ID())
-	} else {
-		fmt.Fprintln(w, "Done.")
-	}
-	return blueprint.ID(), nil
 }

--- a/cmd/beaker/blueprint/create.go
+++ b/cmd/beaker/blueprint/create.go
@@ -82,7 +82,7 @@ func Create(
 		ImageID:     image.ID,
 		ImageTag:    imageTag,
 	}
-	blueprint, err := beaker.CreateBlueprint(ctx, spec, opts.Name)
+	blueprint, err := beaker.CreateImage(ctx, spec, opts.Name)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/beaker/blueprint/create.go
+++ b/cmd/beaker/blueprint/create.go
@@ -13,25 +13,25 @@ import (
 
 func newCreateCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *image.ImageOptions,
+	parentOpts *image.CmdOptions,
 	config *config.Config,
 ) {
 	opts := &image.CreateOptions{}
-	imageID := new(string)
+	imageRef := new(string)
 
 	cmd := parent.Command("create", "Create a new blueprint")
 	cmd.Flag("desc", "Assign a description to the blueprint").StringVar(&opts.Description)
 	cmd.Flag("name", "Assign a name to the blueprint").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created blueprint's ID").Short('q').BoolVar(&opts.Quiet)
-	cmd.Arg("image", "Docker image ID").Required().StringVar(imageID)
+	cmd.Arg("image", "Docker image ID").Required().StringVar(imageRef)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		PrintBeakerDeprecationWarning()
+		printDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}
-		_, err = image.Create(context.TODO(), os.Stdout, beaker, *imageID, opts)
+		_, err = image.Create(context.TODO(), os.Stdout, beaker, *imageRef, opts)
 		return err
 	})
 }

--- a/cmd/beaker/blueprint/inspect.go
+++ b/cmd/beaker/blueprint/inspect.go
@@ -16,7 +16,7 @@ func newInspectCmd(
 	o := &image.InspectOptions{}
 	cmd := parent.Command("inspect", "Display detailed information about one or more blueprints")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		// TODO message reminding to switch to image commands
+		PrintBeakerDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err

--- a/cmd/beaker/blueprint/inspect.go
+++ b/cmd/beaker/blueprint/inspect.go
@@ -1,57 +1,28 @@
 package blueprint
 
 import (
-	"context"
-	"encoding/json"
-	"os"
-
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/allenai/beaker/api"
 	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/config"
 )
 
-type inspectOptions struct {
-	blueprints []string
-}
-
 func newInspectCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *blueprintOptions,
+	parentOpts *image.ImageOptions,
 	config *config.Config,
 ) {
-	o := &inspectOptions{}
+	o := &image.InspectOptions{}
 	cmd := parent.Command("inspect", "Display detailed information about one or more blueprints")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		// TODO message reminding to switch to image commands
+		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}
-		return o.run(beaker)
+		return o.Run(beaker)
 	})
 
-	cmd.Arg("blueprint", "Blueprint name or ID").Required().StringsVar(&o.blueprints)
-}
-
-func (o *inspectOptions) run(beaker *beaker.Client) error {
-	ctx := context.TODO()
-
-	var blueprints []*api.Image
-	for _, name := range o.blueprints {
-		blueprint, err := beaker.Image(ctx, name)
-		if err != nil {
-			return err
-		}
-
-		info, err := blueprint.Get(ctx)
-		if err != nil {
-			return err
-		}
-		blueprints = append(blueprints, info)
-	}
-
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "    ")
-	return encoder.Encode(blueprints)
+	cmd.Arg("blueprint", "Blueprint name or ID").Required().StringsVar(&o.Images)
 }

--- a/cmd/beaker/blueprint/inspect.go
+++ b/cmd/beaker/blueprint/inspect.go
@@ -39,7 +39,7 @@ func (o *inspectOptions) run(beaker *beaker.Client) error {
 
 	var blueprints []*api.Image
 	for _, name := range o.blueprints {
-		blueprint, err := beaker.Blueprint(ctx, name)
+		blueprint, err := beaker.Image(ctx, name)
 		if err != nil {
 			return err
 		}

--- a/cmd/beaker/blueprint/inspect.go
+++ b/cmd/beaker/blueprint/inspect.go
@@ -10,13 +10,13 @@ import (
 
 func newInspectCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *image.ImageOptions,
+	parentOpts *image.CmdOptions,
 	config *config.Config,
 ) {
 	o := &image.InspectOptions{}
 	cmd := parent.Command("inspect", "Display detailed information about one or more blueprints")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		PrintBeakerDeprecationWarning()
+		printDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err

--- a/cmd/beaker/blueprint/pull.go
+++ b/cmd/beaker/blueprint/pull.go
@@ -1,117 +1,30 @@
 package blueprint
 
 import (
-	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-
-	"github.com/docker/docker/api/types"
-	docker "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/pkg/errors"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/config"
 )
 
-type pullOptions struct {
-	blueprint string
-	tag       string
-	quiet     bool
-}
-
 func newPullCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *blueprintOptions,
+	parentOpts *image.ImageOptions,
 	config *config.Config,
 ) {
-	o := &pullOptions{}
+	o := &image.PullOptions{}
 	cmd := parent.Command("pull", "Pull the blueprint's Docker image")
-	cmd.Flag("quiet", "Only display the pulled image's tag").Short('q').BoolVar(&o.quiet)
-	cmd.Arg("blueprint", "Blueprint name or ID").Required().StringVar(&o.blueprint)
-	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.tag)
+	cmd.Flag("quiet", "Only display the pulled image's tag").Short('q').BoolVar(&o.Quiet)
+	cmd.Arg("blueprint", "Blueprint name or ID").Required().StringVar(&o.Image)
+	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.Tag)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		// TODO message reminding to switch to image commands
+		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}
-		return o.run(beaker)
+		return o.Run(beaker)
 	})
-}
-
-func (o *pullOptions) run(beaker *beaker.Client) error {
-	ctx := context.TODO()
-	docker, err := docker.NewEnvClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to create Docker client")
-	}
-
-	blueprint, err := beaker.Image(ctx, o.blueprint)
-	if err != nil {
-		return err
-	}
-
-	repo, err := blueprint.Repository(ctx, false)
-	if err != nil {
-		return errors.WithMessage(err, "failed to retrieve credentials for remote repository")
-	}
-
-	if !o.quiet {
-		fmt.Printf("Pulling %s ...\n", repo.ImageTag)
-	}
-
-	authConfig := types.AuthConfig{
-		ServerAddress: repo.Auth.ServerAddress,
-		Username:      repo.Auth.User,
-		Password:      repo.Auth.Password,
-	}
-	authJSON, err := json.Marshal(authConfig)
-	if err != nil {
-		return errors.Wrap(err, "failed to encode remote repository auth")
-	}
-	authStr := base64.URLEncoding.EncodeToString(authJSON)
-
-	r, err := docker.ImagePull(ctx, repo.ImageTag, types.ImagePullOptions{RegistryAuth: authStr})
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer r.Close()
-
-	// Display push responses as the Docker CLI would. This also translates remote errors.
-	var stream io.Writer = os.Stdout
-	if o.quiet {
-		stream = ioutil.Discard
-	}
-	if err := jsonmessage.DisplayJSONMessagesStream(r, stream, 0, false, nil); err != nil {
-		return errors.WithStack(err)
-	}
-
-	tag := repo.ImageTag
-	if o.tag != "" {
-		if !o.quiet {
-			fmt.Printf("Renaming %s to %s ...\n", repo.ImageTag, o.tag)
-		}
-
-		if err := docker.ImageTag(ctx, repo.ImageTag, o.tag); err != nil {
-			return errors.Wrap(err, "failed to tag image")
-		}
-
-		// We ignore the error here intentionally. Cleaning up is best-effort
-		// and we can't do anything to recover if this fails.
-		_, _ = docker.ImageRemove(ctx, repo.ImageTag, types.ImageRemoveOptions{})
-		tag = o.tag
-	}
-
-	if o.quiet {
-		fmt.Println(tag)
-	} else {
-		fmt.Println("Done.")
-	}
-	return nil
 }

--- a/cmd/beaker/blueprint/pull.go
+++ b/cmd/beaker/blueprint/pull.go
@@ -10,7 +10,7 @@ import (
 
 func newPullCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *image.ImageOptions,
+	parentOpts *image.CmdOptions,
 	config *config.Config,
 ) {
 	o := &image.PullOptions{}
@@ -20,7 +20,7 @@ func newPullCmd(
 	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.Tag)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		PrintBeakerDeprecationWarning()
+		printDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err

--- a/cmd/beaker/blueprint/pull.go
+++ b/cmd/beaker/blueprint/pull.go
@@ -20,7 +20,7 @@ func newPullCmd(
 	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.Tag)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		// TODO message reminding to switch to image commands
+		PrintBeakerDeprecationWarning()
 		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err

--- a/cmd/beaker/blueprint/pull.go
+++ b/cmd/beaker/blueprint/pull.go
@@ -52,7 +52,7 @@ func (o *pullOptions) run(beaker *beaker.Client) error {
 		return errors.Wrap(err, "failed to create Docker client")
 	}
 
-	blueprint, err := beaker.Blueprint(ctx, o.blueprint)
+	blueprint, err := beaker.Image(ctx, o.blueprint)
 	if err != nil {
 		return err
 	}

--- a/cmd/beaker/blueprint/rename.go
+++ b/cmd/beaker/blueprint/rename.go
@@ -15,7 +15,7 @@ func newRenameCmd(
 	o := &image.RenameOptions{}
 	cmd := parent.Command("rename", "Rename an blueprint")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		// TODO message reminding to switch to image commands
+		PrintBeakerDeprecationWarning()
 		return o.Run(parentOpts, config.UserToken)
 	})
 

--- a/cmd/beaker/blueprint/rename.go
+++ b/cmd/beaker/blueprint/rename.go
@@ -9,13 +9,13 @@ import (
 
 func newRenameCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *image.ImageOptions,
+	parentOpts *image.CmdOptions,
 	config *config.Config,
 ) {
 	o := &image.RenameOptions{}
 	cmd := parent.Command("rename", "Rename an blueprint")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		PrintBeakerDeprecationWarning()
+		printDeprecationWarning()
 		return o.Run(parentOpts, config.UserToken)
 	})
 

--- a/cmd/beaker/blueprint/rename.go
+++ b/cmd/beaker/blueprint/rename.go
@@ -37,7 +37,7 @@ func (o *renameOptions) run(parentOpts *blueprintOptions, userToken string) erro
 	if err != nil {
 		return err
 	}
-	blueprint, err := beaker.Blueprint(ctx, o.blueprint)
+	blueprint, err := beaker.Image(ctx, o.blueprint)
 	if err != nil {
 		return err
 	}

--- a/cmd/beaker/blueprint/rename.go
+++ b/cmd/beaker/blueprint/rename.go
@@ -1,61 +1,25 @@
 package blueprint
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/fatih/color"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/config"
 )
 
-type renameOptions struct {
-	quiet     bool
-	blueprint string
-	name      string
-}
-
 func newRenameCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *blueprintOptions,
+	parentOpts *image.ImageOptions,
 	config *config.Config,
 ) {
-	o := &renameOptions{}
+	o := &image.RenameOptions{}
 	cmd := parent.Command("rename", "Rename an blueprint")
-	cmd.Action(func(c *kingpin.ParseContext) error { return o.run(parentOpts, config.UserToken) })
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		// TODO message reminding to switch to image commands
+		return o.Run(parentOpts, config.UserToken)
+	})
 
-	cmd.Flag("quiet", "Only display the blueprint's unique ID").Short('q').BoolVar(&o.quiet)
-	cmd.Arg("blueprint", "Name or ID of the blueprint to rename").Required().StringVar(&o.blueprint)
-	cmd.Arg("new-name", "Unqualified name to assign to the blueprint").Required().StringVar(&o.name)
-}
-
-func (o *renameOptions) run(parentOpts *blueprintOptions, userToken string) error {
-	ctx := context.TODO()
-	beaker, err := beaker.NewClient(parentOpts.addr, userToken)
-	if err != nil {
-		return err
-	}
-	blueprint, err := beaker.Image(ctx, o.blueprint)
-	if err != nil {
-		return err
-	}
-
-	if err := blueprint.SetName(ctx, o.name); err != nil {
-		return err
-	}
-
-	// TODO: This info should probably be part of the client response instead of a separate get.
-	info, err := blueprint.Get(ctx)
-	if err != nil {
-		return err
-	}
-
-	if o.quiet {
-		fmt.Println(info.ID)
-	} else {
-		fmt.Printf("Renamed %s to %s\n", color.BlueString(info.ID), info.DisplayID())
-	}
-	return nil
+	cmd.Flag("quiet", "Only display the blueprint's unique ID").Short('q').BoolVar(&o.Quiet)
+	cmd.Arg("blueprint", "Name or ID of the blueprint to rename").Required().StringVar(&o.Image)
+	cmd.Arg("new-name", "Unqualified name to assign to the blueprint").Required().StringVar(&o.Name)
 }

--- a/cmd/beaker/blueprint/root.go
+++ b/cmd/beaker/blueprint/root.go
@@ -3,14 +3,10 @@ package blueprint
 import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/cmd/beaker/options"
 	"github.com/allenai/beaker/config"
 )
-
-type blueprintOptions struct {
-	*options.AppOptions
-	addr string
-}
 
 // NewBlueprintCmd creates the root command for this subpackage.
 func NewBlueprintCmd(
@@ -18,10 +14,11 @@ func NewBlueprintCmd(
 	parentOpts *options.AppOptions,
 	config *config.Config,
 ) {
-	o := &blueprintOptions{AppOptions: parentOpts}
+	o := &image.ImageOptions{AppOptions: parentOpts}
+	// TODO message reminding to switch to image commands
 	cmd := parent.Command("blueprint", "Manage blueprints")
 
-	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.addr)
+	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.Addr)
 
 	// Add automatic help generation for the command group.
 	var helpSubcommands []string

--- a/cmd/beaker/blueprint/root.go
+++ b/cmd/beaker/blueprint/root.go
@@ -15,7 +15,7 @@ func NewBlueprintCmd(
 	parentOpts *options.AppOptions,
 	config *config.Config,
 ) {
-	o := &image.ImageOptions{AppOptions: parentOpts}
+	o := &image.CmdOptions{AppOptions: parentOpts}
 	cmd := parent.Command("blueprint", "Manage blueprints")
 
 	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.Addr)
@@ -23,7 +23,7 @@ func NewBlueprintCmd(
 	// Add automatic help generation for the command group.
 	var helpSubcommands []string
 	cmd.Command("help", "Show help.").Hidden().Default().PreAction(func(c *kingpin.ParseContext) error {
-		PrintBeakerDeprecationWarning()
+		printDeprecationWarning()
 		fullCommand := append([]string{cmd.Model().Name}, helpSubcommands...)
 		parent.Usage(fullCommand)
 		return nil
@@ -36,7 +36,6 @@ func NewBlueprintCmd(
 	newPullCmd(cmd, o, config)
 }
 
-// PrintBeakerDeprecationWarning prints a warning that blueprint commands will soon be deleted.
-func PrintBeakerDeprecationWarning() {
+func printDeprecationWarning() {
 	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed on April 5.\nPlease update to \"image\" commands to ensure a smooth transition.\n")
 }

--- a/cmd/beaker/blueprint/root.go
+++ b/cmd/beaker/blueprint/root.go
@@ -1,6 +1,7 @@
 package blueprint
 
 import (
+	"github.com/fatih/color"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/allenai/beaker/cmd/beaker/image"
@@ -15,7 +16,6 @@ func NewBlueprintCmd(
 	config *config.Config,
 ) {
 	o := &image.ImageOptions{AppOptions: parentOpts}
-	// TODO message reminding to switch to image commands
 	cmd := parent.Command("blueprint", "Manage blueprints")
 
 	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.Addr)
@@ -23,6 +23,7 @@ func NewBlueprintCmd(
 	// Add automatic help generation for the command group.
 	var helpSubcommands []string
 	cmd.Command("help", "Show help.").Hidden().Default().PreAction(func(c *kingpin.ParseContext) error {
+		PrintBeakerDeprecationWarning()
 		fullCommand := append([]string{cmd.Model().Name}, helpSubcommands...)
 		parent.Usage(fullCommand)
 		return nil
@@ -33,4 +34,9 @@ func NewBlueprintCmd(
 	newInspectCmd(cmd, o, config)
 	newRenameCmd(cmd, o, config)
 	newPullCmd(cmd, o, config)
+}
+
+// PrintBeakerDeprecationWarning prints a warning that blueprint commands will soon be deleted.
+func PrintBeakerDeprecationWarning() {
+	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed on April 5.  Please update to \"image\" commands to ensure a smooth transition.\n")
 }

--- a/cmd/beaker/blueprint/root.go
+++ b/cmd/beaker/blueprint/root.go
@@ -37,5 +37,5 @@ func NewBlueprintCmd(
 }
 
 func printDeprecationWarning() {
-	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed on April 5.\nPlease update to \"image\" commands to ensure a smooth transition.\n")
+	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed soon.\nPlease update to \"image\" commands to ensure a smooth transition.\n")
 }

--- a/cmd/beaker/blueprint/root.go
+++ b/cmd/beaker/blueprint/root.go
@@ -38,5 +38,5 @@ func NewBlueprintCmd(
 
 // PrintBeakerDeprecationWarning prints a warning that blueprint commands will soon be deleted.
 func PrintBeakerDeprecationWarning() {
-	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed on April 5.  Please update to \"image\" commands to ensure a smooth transition.\n")
+	color.Yellow("Beaker \"blueprints\" are now called \"images\", and all \"blueprint\" commands will be removed on April 5.\nPlease update to \"image\" commands to ensure a smooth transition.\n")
 }

--- a/cmd/beaker/experiment/run.go
+++ b/cmd/beaker/experiment/run.go
@@ -101,7 +101,7 @@ func (o *runOptions) run(beaker *beaker.Client) error {
 
 	// Create blueprints in place of images, assuming images do not refer to docker images.
 	images := map[string]string{} // Map image tags to blueprint IDs.
-	for i, task := range spec.Tasks {
+	for _, task := range spec.Tasks {
 		specImage := task.Spec.Image
 
 		// Blueprints take priority over images. Enforce that we have exactly one.
@@ -111,7 +111,6 @@ func (o *runOptions) run(beaker *beaker.Client) error {
 		if specImage == "" {
 			return errors.Errorf("task %q must declare either a blueprint or an image to run", task.Name)
 		}
-		spec.Tasks[i].Spec.Blueprint = specImage
 	}
 
 	if o.dryRun {

--- a/cmd/beaker/experiment/run.go
+++ b/cmd/beaker/experiment/run.go
@@ -12,7 +12,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	beaker "github.com/allenai/beaker/client"
-	"github.com/allenai/beaker/cmd/beaker/blueprint"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/config"
 )
 
@@ -98,25 +98,25 @@ func (o *runOptions) run(beaker *beaker.Client) error {
 	// Create blueprints in place of images.
 	images := map[string]string{} // Map image tags to blueprint IDs.
 	for i, task := range spec.Tasks {
-		image := task.Spec.Image
+		specImage := task.Spec.Image
 		spec.Tasks[i].Spec.Image = ""
 
 		// Blueprints take priority over images. Enforce that we have exactly one.
 		if task.Spec.Blueprint != "" {
 			continue
 		}
-		if image == "" {
+		if specImage == "" {
 			return errors.Errorf("task %q must declare either a blueprint or an image to run", task.Name)
 		}
 
-		blueprintID, ok := images[image]
+		blueprintID, ok := images[specImage]
 		if !ok {
 			var err error
-			blueprintID, err = blueprint.Create(ctx, os.Stdout, beaker, image, nil)
+			blueprintID, err = image.Create(ctx, os.Stdout, beaker, specImage, nil)
 			if err != nil {
-				return errors.WithMessage(err, "failed to create blueprint for image "+strconv.Quote(image))
+				return errors.WithMessage(err, "failed to create blueprint for image "+strconv.Quote(specImage))
 			}
-			images[image] = blueprintID
+			images[specImage] = blueprintID
 		}
 		spec.Tasks[i].Spec.Blueprint = blueprintID
 	}

--- a/cmd/beaker/experiment/run.go
+++ b/cmd/beaker/experiment/run.go
@@ -30,7 +30,6 @@ type runOptions struct {
 
 type specArgs struct {
 	blueprint  string
-	docker     string
 	image      string
 	resultPath string
 	desc       string
@@ -73,7 +72,6 @@ func newRunCmd(
 	// File spec alternatives
 	cmd.Flag("blueprint", "Blueprint containing code to run").StringVar(&o.specArgs.blueprint)
 	cmd.Flag("image", "Beaker image containing code to run").StringVar(&o.specArgs.image)
-	cmd.Flag("docker", "Docker image to run").StringVar(&o.specArgs.docker)
 	cmd.Flag("desc", "Optional description for the experiment").StringVar(&o.specArgs.desc)
 	cmd.Flag("result-path", "Path within the container to which results will be written").
 		PlaceHolder("PATH").Required().StringVar(&o.specArgs.resultPath)
@@ -126,7 +124,7 @@ func (o *runOptions) run(beaker *beaker.Client) error {
 
 	// Create beaker images in place of Docker images, assuming spec images refer to Docker images.
 	images = map[string]string{} // Map Docker image tags to beaker image IDs.
-	color.Yellow("The --image flag should be used to specify the beaker image to use.  This flag will be deprecated to not accept Docker images.  Instead use the --docker flag\n")
+	color.Red("The --image flag should be used to specify the beaker image to use.\nPassing Docker images to the run command will be deprecated soon.\n")
 
 	for i, task := range spec.Tasks {
 		specImage := task.Spec.Image
@@ -158,9 +156,6 @@ func (o *runOptions) run(beaker *beaker.Client) error {
 
 func specFromArgs(args specArgs) (*ExperimentSpec, error) {
 	image := args.image
-	if image == "" {
-		image = args.docker
-	}
 	spec := TaskSpec{
 		Blueprint:  args.blueprint,
 		Image:      image,

--- a/cmd/beaker/experiment/spec.go
+++ b/cmd/beaker/experiment/spec.go
@@ -84,7 +84,7 @@ type TaskSpec struct {
 	// (required) Blueprint describing the code to be run.
 	Blueprint string `yaml:"blueprint"`
 
-	// (deprecated) Name of the Docker image to run.
+	// Image describing code to be run or name of the Docker image to run (deprecated).
 	Image string `yaml:"image,omitempty"`
 
 	// (required) Container path in which experiment will save results.

--- a/cmd/beaker/experiment/spec.go
+++ b/cmd/beaker/experiment/spec.go
@@ -124,9 +124,13 @@ func (s *TaskSpec) ToAPI() (*api.TaskSpec, error) {
 		return nil, err
 	}
 
+	image := s.Image
+	if image == "" {
+		image = s.Blueprint
+	}
+
 	return &api.TaskSpec{
-		Blueprint:    s.Blueprint, // TODO: don't pass blueprint
-		Image:        s.Image,
+		Image:        image,
 		ResultPath:   s.ResultPath,
 		Description:  s.Description,
 		Arguments:    s.Arguments,

--- a/cmd/beaker/experiment/spec.go
+++ b/cmd/beaker/experiment/spec.go
@@ -124,12 +124,9 @@ func (s *TaskSpec) ToAPI() (*api.TaskSpec, error) {
 		return nil, err
 	}
 
-	if s.Image != "" {
-		return nil, errors.New(`"image" field is deprecated; please define "blueprint" instead`)
-	}
-
 	return &api.TaskSpec{
-		Blueprint:    s.Blueprint,
+		Blueprint:    s.Blueprint, // TODO: don't pass blueprint
+		Image:        s.Image,
 		ResultPath:   s.ResultPath,
 		Description:  s.Description,
 		Arguments:    s.Arguments,

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -30,7 +30,7 @@ type CreateOptions struct {
 
 func newCreateCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *imageOptions,
+	parentOpts *ImageOptions,
 	config *config.Config,
 ) {
 	opts := &CreateOptions{}
@@ -43,7 +43,7 @@ func newCreateCmd(
 	cmd.Arg("image", "Docker image ID").Required().StringVar(image)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -1,0 +1,149 @@
+package image
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/allenai/beaker/api"
+	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/config"
+)
+
+// CreateOptions wraps options used to create an image.
+type CreateOptions struct {
+	Description string
+	Name        string
+	Quiet       bool
+}
+
+func newCreateCmd(
+	parent *kingpin.CmdClause,
+	parentOpts *imageOptions,
+	config *config.Config,
+) {
+	opts := &CreateOptions{}
+	image := new(string)
+
+	cmd := parent.Command("create", "Create a new image")
+	cmd.Flag("desc", "Assign a description to the image").StringVar(&opts.Description)
+	cmd.Flag("name", "Assign a name to the image").Short('n').StringVar(&opts.Name)
+	cmd.Flag("quiet", "Only display created image's ID").Short('q').BoolVar(&opts.Quiet)
+	cmd.Arg("image", "Docker image ID").Required().StringVar(image)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		if err != nil {
+			return err
+		}
+		_, err = Create(context.TODO(), os.Stdout, beaker, *image, opts)
+		return err
+	})
+}
+
+// Create creates a new image and returns its ID.
+func Create(
+	ctx context.Context,
+	w io.Writer,
+	beaker *beaker.Client,
+	imageTag string,
+	opts *CreateOptions,
+) (string, error) {
+	if w == nil {
+		w = ioutil.Discard
+	}
+	if opts == nil {
+		opts = &CreateOptions{}
+	}
+
+	docker, err := docker.NewEnvClient()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create Docker client")
+	}
+
+	dockerImage, _, err := docker.ImageInspectWithRaw(ctx, imageTag)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	spec := api.ImageSpec{
+		Description: opts.Description,
+		ImageID:     dockerImage.ID,
+		ImageTag:    imageTag,
+	}
+	image, err := beaker.CreateImage(ctx, spec, opts.Name)
+	if err != nil {
+		return "", err
+	}
+
+	if !opts.Quiet {
+		if opts.Name == "" {
+			fmt.Fprintf(w, "Pushing %s as %s ...\n", imageTag, color.BlueString(image.ID()))
+		} else {
+			fmt.Fprintf(w, "Pushing %s as %s (%s)...\n", imageTag, color.BlueString(opts.Name), image.ID())
+		}
+	}
+
+	repo, err := image.Repository(ctx, true)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to retrieve credentials for remote repository")
+	}
+
+	// Tag the image to the remote repository.
+	if err := docker.ImageTag(ctx, imageTag, repo.ImageTag); err != nil {
+		return "", errors.Wrap(err, "failed to set remote image tag")
+	}
+	defer func() {
+		// We ignore the error here intentionally. Cleaning up is best-effort
+		// and we can't do anything to recover if this fails.
+		_, _ = docker.ImageRemove(ctx, repo.ImageTag, types.ImageRemoveOptions{})
+	}()
+
+	authConfig := types.AuthConfig{
+		ServerAddress: repo.Auth.ServerAddress,
+		Username:      repo.Auth.User,
+		Password:      repo.Auth.Password,
+	}
+	authJSON, err := json.Marshal(authConfig)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to encode remote repository auth")
+	}
+	authStr := base64.URLEncoding.EncodeToString(authJSON)
+
+	r, err := docker.ImagePush(ctx, repo.ImageTag, types.ImagePushOptions{RegistryAuth: authStr})
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer r.Close()
+
+	// Display push responses as the Docker CLI would. This also translates remote errors.
+	var stream io.Writer = os.Stdout
+	if opts.Quiet {
+		stream = ioutil.Discard
+	}
+	if err := jsonmessage.DisplayJSONMessagesStream(r, stream, 0, false, nil); err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	if err := image.Commit(ctx); err != nil {
+		return "", errors.WithMessage(err, "failed to commit image")
+	}
+
+	if opts.Quiet {
+		fmt.Fprintln(w, image.ID())
+	} else {
+		fmt.Fprintln(w, "Done.")
+	}
+	return image.ID(), nil
+}

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -30,7 +30,7 @@ type CreateOptions struct {
 
 func newCreateCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *ImageOptions,
+	parentOpts *CmdOptions,
 	config *config.Config,
 ) {
 	opts := &CreateOptions{}

--- a/cmd/beaker/image/inspect.go
+++ b/cmd/beaker/image/inspect.go
@@ -20,7 +20,7 @@ type InspectOptions struct {
 
 func newInspectCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *ImageOptions,
+	parentOpts *CmdOptions,
 	config *config.Config,
 ) {
 	o := &InspectOptions{}

--- a/cmd/beaker/image/inspect.go
+++ b/cmd/beaker/image/inspect.go
@@ -1,0 +1,57 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/allenai/beaker/api"
+	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/config"
+)
+
+type inspectOptions struct {
+	images []string
+}
+
+func newInspectCmd(
+	parent *kingpin.CmdClause,
+	parentOpts *imageOptions,
+	config *config.Config,
+) {
+	o := &inspectOptions{}
+	cmd := parent.Command("inspect", "Display detailed information about one or more images")
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		if err != nil {
+			return err
+		}
+		return o.run(beaker)
+	})
+
+	cmd.Arg("image", "Image name or ID").Required().StringsVar(&o.images)
+}
+
+func (o *inspectOptions) run(beaker *beaker.Client) error {
+	ctx := context.TODO()
+
+	var images []*api.Image
+	for _, name := range o.images {
+		image, err := beaker.Image(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		info, err := image.Get(ctx)
+		if err != nil {
+			return err
+		}
+		images = append(images, info)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "    ")
+	return encoder.Encode(images)
+}

--- a/cmd/beaker/image/inspect.go
+++ b/cmd/beaker/image/inspect.go
@@ -12,33 +12,37 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-type inspectOptions struct {
-	images []string
+// InspectOptions holds the images to inspect
+// TODO: make unexported once not needed by blueprint command
+type InspectOptions struct {
+	Images []string
 }
 
 func newInspectCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *imageOptions,
+	parentOpts *ImageOptions,
 	config *config.Config,
 ) {
-	o := &inspectOptions{}
+	o := &InspectOptions{}
 	cmd := parent.Command("inspect", "Display detailed information about one or more images")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
 		if err != nil {
 			return err
 		}
-		return o.run(beaker)
+		return o.Run(beaker)
 	})
 
-	cmd.Arg("image", "Image name or ID").Required().StringsVar(&o.images)
+	cmd.Arg("image", "Image name or ID").Required().StringsVar(&o.Images)
 }
 
-func (o *inspectOptions) run(beaker *beaker.Client) error {
+// Run runs the inspect command on the InspectOptions images
+// TODO: make unexported once not needed by blueprint command
+func (o *InspectOptions) Run(beaker *beaker.Client) error {
 	ctx := context.TODO()
 
 	var images []*api.Image
-	for _, name := range o.images {
+	for _, name := range o.Images {
 		image, err := beaker.Image(ctx, name)
 		if err != nil {
 			return err

--- a/cmd/beaker/image/pull.go
+++ b/cmd/beaker/image/pull.go
@@ -1,0 +1,117 @@
+package image
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/pkg/errors"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/config"
+)
+
+type pullOptions struct {
+	image string
+	tag   string
+	quiet bool
+}
+
+func newPullCmd(
+	parent *kingpin.CmdClause,
+	parentOpts *imageOptions,
+	config *config.Config,
+) {
+	o := &pullOptions{}
+	cmd := parent.Command("pull", "Pull the image's Docker image")
+	cmd.Flag("quiet", "Only display the pulled image's tag").Short('q').BoolVar(&o.quiet)
+	cmd.Arg("image", "Image name or ID").Required().StringVar(&o.image)
+	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.tag)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		if err != nil {
+			return err
+		}
+		return o.run(beaker)
+	})
+}
+
+func (o *pullOptions) run(beaker *beaker.Client) error {
+	ctx := context.TODO()
+	docker, err := docker.NewEnvClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to create Docker client")
+	}
+
+	image, err := beaker.Image(ctx, o.image)
+	if err != nil {
+		return err
+	}
+
+	repo, err := image.Repository(ctx, false)
+	if err != nil {
+		return errors.WithMessage(err, "failed to retrieve credentials for remote repository")
+	}
+
+	if !o.quiet {
+		fmt.Printf("Pulling %s ...\n", repo.ImageTag)
+	}
+
+	authConfig := types.AuthConfig{
+		ServerAddress: repo.Auth.ServerAddress,
+		Username:      repo.Auth.User,
+		Password:      repo.Auth.Password,
+	}
+	authJSON, err := json.Marshal(authConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode remote repository auth")
+	}
+	authStr := base64.URLEncoding.EncodeToString(authJSON)
+
+	r, err := docker.ImagePull(ctx, repo.ImageTag, types.ImagePullOptions{RegistryAuth: authStr})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer r.Close()
+
+	// Display push responses as the Docker CLI would. This also translates remote errors.
+	var stream io.Writer = os.Stdout
+	if o.quiet {
+		stream = ioutil.Discard
+	}
+	if err := jsonmessage.DisplayJSONMessagesStream(r, stream, 0, false, nil); err != nil {
+		return errors.WithStack(err)
+	}
+
+	tag := repo.ImageTag
+	if o.tag != "" {
+		if !o.quiet {
+			fmt.Printf("Renaming %s to %s ...\n", repo.ImageTag, o.tag)
+		}
+
+		if err := docker.ImageTag(ctx, repo.ImageTag, o.tag); err != nil {
+			return errors.Wrap(err, "failed to tag image")
+		}
+
+		// We ignore the error here intentionally. Cleaning up is best-effort
+		// and we can't do anything to recover if this fails.
+		_, _ = docker.ImageRemove(ctx, repo.ImageTag, types.ImageRemoveOptions{})
+		tag = o.tag
+	}
+
+	if o.quiet {
+		fmt.Println(tag)
+	} else {
+		fmt.Println("Done.")
+	}
+	return nil
+}

--- a/cmd/beaker/image/pull.go
+++ b/cmd/beaker/image/pull.go
@@ -29,7 +29,7 @@ type PullOptions struct {
 
 func newPullCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *ImageOptions,
+	parentOpts *CmdOptions,
 	config *config.Config,
 ) {
 	o := &PullOptions{}

--- a/cmd/beaker/image/pull.go
+++ b/cmd/beaker/image/pull.go
@@ -33,7 +33,7 @@ func newPullCmd(
 	config *config.Config,
 ) {
 	o := &PullOptions{}
-	cmd := parent.Command("pull", "Pull the image's Docker image")
+	cmd := parent.Command("pull", "Pull the image's cooresponding Docker image")
 	cmd.Flag("quiet", "Only display the pulled image's tag").Short('q').BoolVar(&o.Quiet)
 	cmd.Arg("image", "Image name or ID").Required().StringVar(&o.Image)
 	cmd.Arg("tag", "Name and optional tag in the 'name:tag' format").StringVar(&o.Tag)

--- a/cmd/beaker/image/rename.go
+++ b/cmd/beaker/image/rename.go
@@ -11,38 +11,42 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-type renameOptions struct {
-	quiet bool
-	image string
-	name  string
+// RenameOptions defines settings for image rename command
+// TODO: make RenameOptions and fields unexported once not needed by blueprint command
+type RenameOptions struct {
+	Quiet bool
+	Image string
+	Name  string
 }
 
 func newRenameCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *imageOptions,
+	parentOpts *ImageOptions,
 	config *config.Config,
 ) {
-	o := &renameOptions{}
+	o := &RenameOptions{}
 	cmd := parent.Command("rename", "Rename an image")
-	cmd.Action(func(c *kingpin.ParseContext) error { return o.run(parentOpts, config.UserToken) })
+	cmd.Action(func(c *kingpin.ParseContext) error { return o.Run(parentOpts, config.UserToken) })
 
-	cmd.Flag("quiet", "Only display the image's unique ID").Short('q').BoolVar(&o.quiet)
-	cmd.Arg("image", "Name or ID of the image to rename").Required().StringVar(&o.image)
-	cmd.Arg("new-name", "Unqualified name to assign to the image").Required().StringVar(&o.name)
+	cmd.Flag("quiet", "Only display the image's unique ID").Short('q').BoolVar(&o.Quiet)
+	cmd.Arg("image", "Name or ID of the image to rename").Required().StringVar(&o.Image)
+	cmd.Arg("new-name", "Unqualified name to assign to the image").Required().StringVar(&o.Name)
 }
 
-func (o *renameOptions) run(parentOpts *imageOptions, userToken string) error {
+// Run executes beaker image rename command
+// TODO: make Run unexported once not needed by blueprint command
+func (o *RenameOptions) Run(parentOpts *ImageOptions, userToken string) error {
 	ctx := context.TODO()
-	beaker, err := beaker.NewClient(parentOpts.addr, userToken)
+	beaker, err := beaker.NewClient(parentOpts.Addr, userToken)
 	if err != nil {
 		return err
 	}
-	image, err := beaker.Image(ctx, o.image)
+	image, err := beaker.Image(ctx, o.Image)
 	if err != nil {
 		return err
 	}
 
-	if err := image.SetName(ctx, o.name); err != nil {
+	if err := image.SetName(ctx, o.Name); err != nil {
 		return err
 	}
 
@@ -52,7 +56,7 @@ func (o *renameOptions) run(parentOpts *imageOptions, userToken string) error {
 		return err
 	}
 
-	if o.quiet {
+	if o.Quiet {
 		fmt.Println(info.ID)
 	} else {
 		fmt.Printf("Renamed %s to %s\n", color.BlueString(info.ID), info.DisplayID())

--- a/cmd/beaker/image/rename.go
+++ b/cmd/beaker/image/rename.go
@@ -1,0 +1,61 @@
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fatih/color"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/config"
+)
+
+type renameOptions struct {
+	quiet bool
+	image string
+	name  string
+}
+
+func newRenameCmd(
+	parent *kingpin.CmdClause,
+	parentOpts *imageOptions,
+	config *config.Config,
+) {
+	o := &renameOptions{}
+	cmd := parent.Command("rename", "Rename an image")
+	cmd.Action(func(c *kingpin.ParseContext) error { return o.run(parentOpts, config.UserToken) })
+
+	cmd.Flag("quiet", "Only display the image's unique ID").Short('q').BoolVar(&o.quiet)
+	cmd.Arg("image", "Name or ID of the image to rename").Required().StringVar(&o.image)
+	cmd.Arg("new-name", "Unqualified name to assign to the image").Required().StringVar(&o.name)
+}
+
+func (o *renameOptions) run(parentOpts *imageOptions, userToken string) error {
+	ctx := context.TODO()
+	beaker, err := beaker.NewClient(parentOpts.addr, userToken)
+	if err != nil {
+		return err
+	}
+	image, err := beaker.Image(ctx, o.image)
+	if err != nil {
+		return err
+	}
+
+	if err := image.SetName(ctx, o.name); err != nil {
+		return err
+	}
+
+	// TODO: This info should probably be part of the client response instead of a separate get.
+	info, err := image.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	if o.quiet {
+		fmt.Println(info.ID)
+	} else {
+		fmt.Printf("Renamed %s to %s\n", color.BlueString(info.ID), info.DisplayID())
+	}
+	return nil
+}

--- a/cmd/beaker/image/rename.go
+++ b/cmd/beaker/image/rename.go
@@ -21,7 +21,7 @@ type RenameOptions struct {
 
 func newRenameCmd(
 	parent *kingpin.CmdClause,
-	parentOpts *ImageOptions,
+	parentOpts *CmdOptions,
 	config *config.Config,
 ) {
 	o := &RenameOptions{}
@@ -35,7 +35,7 @@ func newRenameCmd(
 
 // Run executes beaker image rename command
 // TODO: make Run unexported once not needed by blueprint command
-func (o *RenameOptions) Run(parentOpts *ImageOptions, userToken string) error {
+func (o *RenameOptions) Run(parentOpts *CmdOptions, userToken string) error {
 	ctx := context.TODO()
 	beaker, err := beaker.NewClient(parentOpts.Addr, userToken)
 	if err != nil {

--- a/cmd/beaker/image/root.go
+++ b/cmd/beaker/image/root.go
@@ -1,0 +1,39 @@
+package image
+
+import (
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/allenai/beaker/cmd/beaker/options"
+	"github.com/allenai/beaker/config"
+)
+
+type imageOptions struct {
+	*options.AppOptions
+	addr string
+}
+
+// NewImageCmd creates the root command for this subpackage.
+func NewImageCmd(
+	parent *kingpin.Application,
+	parentOpts *options.AppOptions,
+	config *config.Config,
+) {
+	o := &imageOptions{AppOptions: parentOpts}
+	cmd := parent.Command("image", "Manage images")
+
+	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.addr)
+
+	// Add automatic help generation for the command group.
+	var helpSubcommands []string
+	cmd.Command("help", "Show help.").Hidden().Default().PreAction(func(c *kingpin.ParseContext) error {
+		fullCommand := append([]string{cmd.Model().Name}, helpSubcommands...)
+		parent.Usage(fullCommand)
+		return nil
+	}).Arg("command", "Show help on command.").StringsVar(&helpSubcommands)
+
+	// Attach subcommands.
+	newCreateCmd(cmd, o, config)
+	newInspectCmd(cmd, o, config)
+	newRenameCmd(cmd, o, config)
+	newPullCmd(cmd, o, config)
+}

--- a/cmd/beaker/image/root.go
+++ b/cmd/beaker/image/root.go
@@ -7,9 +7,11 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-type imageOptions struct {
+// ImageOptions defines the options for image commands
+// TODO: make ImageOptions and Addr unexported once not needed by blueprint command
+type ImageOptions struct {
 	*options.AppOptions
-	addr string
+	Addr string
 }
 
 // NewImageCmd creates the root command for this subpackage.
@@ -18,10 +20,10 @@ func NewImageCmd(
 	parentOpts *options.AppOptions,
 	config *config.Config,
 ) {
-	o := &imageOptions{AppOptions: parentOpts}
+	o := &ImageOptions{AppOptions: parentOpts}
 	cmd := parent.Command("image", "Manage images")
 
-	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.addr)
+	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.Addr)
 
 	// Add automatic help generation for the command group.
 	var helpSubcommands []string

--- a/cmd/beaker/image/root.go
+++ b/cmd/beaker/image/root.go
@@ -7,9 +7,9 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-// ImageOptions defines the options for image commands
-// TODO: make ImageOptions and Addr unexported once not needed by blueprint command
-type ImageOptions struct {
+// CmdOptions defines the options for image commands
+// TODO: make CmdOptions and Addr unexported once not needed by blueprint command
+type CmdOptions struct {
 	*options.AppOptions
 	Addr string
 }
@@ -20,7 +20,7 @@ func NewImageCmd(
 	parentOpts *options.AppOptions,
 	config *config.Config,
 ) {
-	o := &ImageOptions{AppOptions: parentOpts}
+	o := &CmdOptions{AppOptions: parentOpts}
 	cmd := parent.Command("image", "Manage images")
 
 	cmd.Flag("addr", "Address of the Beaker service.").Default(config.BeakerAddress).StringVar(&o.Addr)

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/allenai/beaker/cmd/beaker/dataset"
 	"github.com/allenai/beaker/cmd/beaker/experiment"
 	"github.com/allenai/beaker/cmd/beaker/group"
+	"github.com/allenai/beaker/cmd/beaker/image"
 	"github.com/allenai/beaker/cmd/beaker/options"
 	"github.com/allenai/beaker/cmd/beaker/task"
 	"github.com/allenai/beaker/config"
@@ -55,10 +56,11 @@ func newApp(config *config.Config) (*options.AppOptions, error) {
 
 	// Build out sub-command groups.
 	alpha.NewAlphaCmd(app, o, config)
-	blueprint.NewBlueprintCmd(app, o, config)
+	blueprint.NewBlueprintCmd(app, o, config)  // TODO: delete blueprint command
 	dataset.NewDatasetCmd(app, o, config)
 	experiment.NewExperimentCmd(app, o, config)
 	group.NewGroupCmd(app, o, config)
+	image.NewImageCmd(app, o, config)
 	task.NewTaskCmd(app, o, config)
 
 	// Attach sub-commands.

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -56,7 +56,7 @@ func newApp(config *config.Config) (*options.AppOptions, error) {
 
 	// Build out sub-command groups.
 	alpha.NewAlphaCmd(app, o, config)
-	blueprint.NewBlueprintCmd(app, o, config)  // TODO: delete blueprint command
+	blueprint.NewBlueprintCmd(app, o, config) // TODO: delete blueprint command
 	dataset.NewDatasetCmd(app, o, config)
 	experiment.NewExperimentCmd(app, o, config)
 	group.NewGroupCmd(app, o, config)

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -1,4 +1,4 @@
-| Beaker "blueprints" are now called "images", and all "blueprint" commands will be removed on April 5. Please update to "image" commands to ensure a smooth transition |
+| Beaker "blueprints" are now called "images", and all "blueprint" commands will be removed soon. Please update to "image" commands to ensure a smooth transition |
 | --- |
 
 # Working with Blueprints

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -123,12 +123,12 @@ This is a single file.
 ## Use Datasets in an Experiment
 
 To demonstrate how to use a dataset in an experiment, we'll run the same find command we ran above
-as a Beaker experiment. The code for this experiment's blueprint can be found
+as a Beaker experiment. The code for this experiment's image can be found
 [here](../examples/list-files).
 
 ```bash
 beaker experiment run \
-    --blueprint example/list-files \
+    --image example/list-files \
     --env LIST_DIR=/data \
     --source my-file-dataset:/data/single \
     --source my-dir-dataset:/data/multi \

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,13 +1,10 @@
-| Beaker "blueprints" are now called "images", and all "blueprint" commands will be removed on April 5. Please update to "image" commands to ensure a smooth transition |
-| --- |
+# Working with Images
 
-# Working with Blueprints
-
-Blueprints are Beaker's unit of executable code. A blueprint combines a Docker image with metadata,
+Images are Beaker's unit of executable code. A beaker image combines a Docker image with metadata,
 such as its author and description, and an optional richer narrative in markdown. Please refer to
-[the wordcount example](https://beaker-pub.allenai.org/bp/bp_qbjvcda1sed7) for an overview.
+[the wordcount example](https://beaker-pub.allenai.org/im/im_qbjvcda1sed7) for an overview.
 
-Like datasets, blueprints are immutable. The following example shows how to create and use blueprints.
+Like datasets, images are immutable. The following example shows how to create and use images.
 
 ## Preparation: Build a Docker Image
 
@@ -21,12 +18,12 @@ docker build -t wordcount <path/to/wordcount/directory>
 
 ## Create and Upload
 
-You can create and upload any image as a blueprint with a single command. Behind the scenes, Beaker pushes your
+You can create and upload any Docker image as a beaker image with a single command. Behind the scenes, Beaker pushes your
 Docker image to a private repository. This guarantees that the image will remain available and
 unchanged for future experiments.
 
 ```
-▶ beaker blueprint create --name wordcount wordcount
+▶ beaker image create --name wordcount wordcount
 Pushing wordcount as wordcount (bp_qbjvcda1sed7)...
 The push refers to repository [gcr.io/ai2-beaker-core/public/bduufrl06q5ner2l0440]
 172b7a93847f: Preparing
@@ -39,21 +36,21 @@ latest: digest: sha256:4c70545c15cca8d30b3adfd004a708fcdec910f162fa825861fe13820
 Done.
 ```
 
-Notice that each blueprint is assigned a unique ID in addition to the name we chose. Any object,
-including blueprints, can be referred to by its name or ID. Like any object, a blueprint can be
+Notice that each image is assigned a unique ID in addition to the name we chose. Any object,
+including images, can be referred to by its name or ID. Like any object, an image can be
 renamed, but its ID is guaranteed to remain stable. The following two commands are equivalent:
 
 ```bash
-beaker blueprint inspect examples/wordcount
-beaker blueprint inspect bp_qbjvcda1sed7
+beaker image inspect examples/wordcount
+beaker image inspect im_qbjvcda1sed7
 ```
 
 ## Inspect
 
-A blueprint's metadata can be retrieved with `beaker blueprint inspect`.
+An image's metadata can be retrieved with `beaker image inspect`.
 
 ```
-▶ beaker blueprint inspect examples/wordcount
+▶ beaker image inspect examples/wordcount
 [
     {
         "id": "bp_qbjvcda1sed7",
@@ -73,10 +70,10 @@ A blueprint's metadata can be retrieved with `beaker blueprint inspect`.
 
 ## Download
 
-You can pull a blueprint to your local machine at any time with `beaker blueprint pull`.
+You can pull an image to your local machine at any time with `beaker image pull`.
 
 ```
-▶ beaker blueprint pull examples/wordcount
+▶ beaker image pull examples/wordcount
 Pulling gcr.io/ai2-beaker-core/public/bduufrl06q5ner2l0440 ...
 latest: Pulling from ai2-beaker-core/public/bduufrl06q5ner2l0440
 Digest: sha256:4c70545c15cca8d30b3adfd004a708fcdec910f162fa825861fe138200f80e19
@@ -89,12 +86,12 @@ internally assigned tag  `gcr.io/ai2-beaker-core/public/bduufrl06q5ner2l0440` by
 a more human-friendly tag, set it with an additional argument:
 
 ```
-▶ beaker blueprint pull examples/wordcount friendly-name
+▶ beaker image pull examples/wordcount friendly-name
 ```
 
 ## Cleanup
 
-To clean up, simply `docker image rm` any images created above.
+To clean up, simply `docker image rm` any Docker images created above.
 
-Because blueprints are immutable, they can't be deleted. It will be possible to archive them in the
+Because images are immutable, they can't be deleted. It will be possible to archive them in the
 near future.

--- a/docs/multistage-experiments.md
+++ b/docs/multistage-experiments.md
@@ -10,7 +10,7 @@ A task may depend on the results of another task in its experiment.
 In this example, the `merge` task depends on the results of the `count-1`, `count-2`, and `count-3` tasks.
 The count tasks are executed in parallel and the merge task runs automatically once they complete.
 
-This example uses two blueprints:
+This example uses two images:
 1. `example/wordcount`: Counts all words in the `/input` directory and produces a `word_count` metric.
 2. `example/merge-wordcount`: Sums the `word_count` metrics in the `/input` directory.
 
@@ -23,7 +23,7 @@ tasks:
   - name: count-1
     spec:
       description: Count words in wordcount-1
-      blueprint: example/wordcount
+      image: example/wordcount
       resultPath: /output
       datasetMounts:
         - datasetId: example/wordcount-1
@@ -34,7 +34,7 @@ tasks:
   - name: merge
     spec:
       description: Merge wordcounts
-      blueprint: example/merge-wordcount
+      image: example/merge-wordcount
       resultPath: /output
     dependsOn:
      - parentName: count-1

--- a/docs/parallel-wordcount.yml
+++ b/docs/parallel-wordcount.yml
@@ -3,7 +3,7 @@ tasks:
   - name: count-1
     spec:
       description: Count words in wordcount-1
-      blueprint: example/wordcount
+      image: example/wordcount
       resultPath: /output
       datasetMounts:
         - datasetId: example/wordcount-1
@@ -12,7 +12,7 @@ tasks:
   - name: count-2
     spec:
       description: Count words in wordcount-2
-      blueprint: example/wordcount
+      image: example/wordcount
       resultPath: /output
       datasetMounts:
         - datasetId: example/wordcount-2
@@ -21,7 +21,7 @@ tasks:
   - name: count-3
     spec:
       description: Count words in wordcount-3
-      blueprint: example/wordcount
+      image: example/wordcount
       resultPath: /output
       datasetMounts:
         - datasetId: example/wordcount-3
@@ -30,7 +30,7 @@ tasks:
   - name: merge
     spec:
       description: Merge wordcounts
-      blueprint: example/merge-wordcount
+      image: example/merge-wordcount
       resultPath: /output
     dependsOn:
      - parentName: count-1


### PR DESCRIPTION
This makes a `beaker image` command for every `beaker blueprint` command, and a `--image` flag for every `--blueprint` flag.  Existing `--image` flags (for docker images) continue to work, and a deprecation warning is printed for any commands we plan to remove soon.