### PR TITLE
Add beaker dataset ls

### DIFF
--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -27,7 +27,7 @@ func newListCmd(
 	config *config.Config,
 ) {
 	o := &listOptions{}
-	cmd := parent.Command("ls", "List files in a dataset")
+	cmd := parent.Command("ls", "List files in a dataset.")
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
 		if err != nil {

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	bytefmt "github.com/beaker/fileheap/bytefmt"
+	fileheap "github.com/beaker/fileheap/client"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	beaker "github.com/allenai/beaker/client"
 	"github.com/allenai/beaker/config"
-	bytefmt "github.com/beaker/fileheap/bytefmt"
-	fileheap "github.com/beaker/fileheap/client"
 )
 
 type listOptions struct {

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -34,8 +34,8 @@ func newListCmd(
 		return o.run(beaker)
 	})
 
-	cmd.Arg("dataset", "Dataset name or ID.").Required().StringVar(&o.dataset)
-	cmd.Arg("prefix", "Path prefix.").StringVar(&o.prefix)
+	cmd.Arg("dataset", "Dataset name or ID").Required().StringVar(&o.dataset)
+	cmd.Arg("prefix", "Path prefix").StringVar(&o.prefix)
 	cmd.Flag("json", "Output a JSON object for each file.").BoolVar(&o.json)
 }
 

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -66,7 +66,7 @@ func (o *listOptions) run(beaker *client.Client) error {
 			buf, err := json.Marshal(fileInfo{
 				Path:    info.Path,
 				Size:    info.Size,
-				Updated: info.Updated.UnixNano(),
+				Updated: info.Updated,
 			})
 			if err != nil {
 				return err
@@ -90,7 +90,7 @@ func (o *listOptions) run(beaker *client.Client) error {
 }
 
 type fileInfo struct {
-	Path    string `json:"path"`
-	Size    int64  `json:"bytes"`
-	Updated int64  `json:"updated"`
+	Path    string    `json:"path"`
+	Size    int64     `json:"bytes"`
+	Updated time.Time `json:"updated"`
 }

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -1,0 +1,99 @@
+package dataset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	beaker "github.com/allenai/beaker/client"
+	"github.com/allenai/beaker/config"
+	bytefmt "github.com/beaker/fileheap/bytefmt"
+	fileheap "github.com/beaker/fileheap/client"
+)
+
+type listOptions struct {
+	dataset string
+	prefix  string
+	json    bool
+}
+
+func newListCmd(
+	parent *kingpin.CmdClause,
+	parentOpts *datasetOptions,
+	config *config.Config,
+) {
+	o := &listOptions{}
+	cmd := parent.Command("ls", "List files in a dataset")
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		if err != nil {
+			return err
+		}
+		return o.run(beaker)
+	})
+
+	cmd.Arg("dataset", "Dataset name or ID.").Required().StringVar(&o.dataset)
+	cmd.Arg("prefix", "Path prefix.").StringVar(&o.prefix)
+	cmd.Flag("json", "Output a JSON object for each file.").BoolVar(&o.json)
+}
+
+func (o *listOptions) run(beaker *beaker.Client) error {
+	ctx := context.Background()
+	dataset, err := beaker.Dataset(ctx, o.dataset)
+	if err != nil {
+		return err
+	}
+
+	if dataset.Storage == nil {
+		return errors.New("dataset ls is only supported for FileHeap datasets")
+	}
+
+	var totalFiles, totalBytes int64
+	files := dataset.Storage.Files(ctx, o.prefix)
+	for {
+		info, err := files.Next()
+		if err == fileheap.ErrDone {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		totalFiles++
+		totalBytes += info.Size
+
+		if o.json {
+			buf, err := json.Marshal(fileInfo{
+				Path:    info.Path,
+				Size:    info.Size,
+				Updated: info.Updated.UnixNano(),
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(buf))
+		} else {
+			fmt.Printf(
+				"%10d  %s  %s\n",
+				info.Size,
+				info.Updated.Format(time.RFC3339),
+				info.Path,
+			)
+		}
+	}
+
+	if !o.json {
+		fmt.Printf("Total: %d files, %d bytes (%s)\n", totalFiles, totalBytes, bytefmt.FormatBytes(totalBytes))
+	}
+
+	return nil
+}
+
+type fileInfo struct {
+	Path    string `json:"path"`
+	Size    int64  `json:"bytes"`
+	Updated int64  `json:"updated"`
+}

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -16,8 +16,12 @@ import (
 type listOptions struct {
 	dataset string
 	prefix  string
-	json    bool
+	format  string
 }
+
+const (
+	formatJSON = "json"
+)
 
 func newListCmd(
 	parent *kingpin.CmdClause,
@@ -36,7 +40,7 @@ func newListCmd(
 
 	cmd.Arg("dataset", "Dataset name or ID").Required().StringVar(&o.dataset)
 	cmd.Arg("prefix", "Path prefix").StringVar(&o.prefix)
-	cmd.Flag("json", "Output a JSON object for each file.").BoolVar(&o.json)
+	cmd.Flag("format", "Output format").EnumVar(&o.format, formatJSON)
 }
 
 func (o *listOptions) run(beaker *client.Client) error {
@@ -62,7 +66,8 @@ func (o *listOptions) run(beaker *client.Client) error {
 		totalFiles++
 		totalBytes += info.Size
 
-		if o.json {
+		switch o.format {
+		case formatJSON:
 			buf, err := json.Marshal(fileInfo{
 				Path:    info.Path,
 				Size:    info.Size,
@@ -72,7 +77,7 @@ func (o *listOptions) run(beaker *client.Client) error {
 				return err
 			}
 			fmt.Println(string(buf))
-		} else {
+		default:
 			fmt.Printf(
 				"%10s  %s  %s\n",
 				bytefmt.FormatBytes(info.Size),
@@ -82,7 +87,9 @@ func (o *listOptions) run(beaker *client.Client) error {
 		}
 	}
 
-	if !o.json {
+	switch o.format {
+	case formatJSON:
+	default:
 		fmt.Printf("Total: %d files, %s\n", totalFiles, bytefmt.FormatBytes(totalBytes))
 	}
 

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -91,6 +91,6 @@ func (o *listOptions) run(beaker *client.Client) error {
 
 type fileInfo struct {
 	Path    string    `json:"path"`
-	Size    int64     `json:"bytes"`
+	Size    int64     `json:"size"`
 	Updated time.Time `json:"updated"`
 }

--- a/cmd/beaker/dataset/ls.go
+++ b/cmd/beaker/dataset/ls.go
@@ -77,8 +77,8 @@ func (o *listOptions) run(beaker *beaker.Client) error {
 			fmt.Println(string(buf))
 		} else {
 			fmt.Printf(
-				"%10d  %s  %s\n",
-				info.Size,
+				"%10s  %s  %s\n",
+				bytefmt.FormatBytes(info.Size),
 				info.Updated.Format(time.RFC3339),
 				info.Path,
 			)
@@ -86,7 +86,7 @@ func (o *listOptions) run(beaker *beaker.Client) error {
 	}
 
 	if !o.json {
-		fmt.Printf("Total: %d files, %d bytes (%s)\n", totalFiles, totalBytes, bytefmt.FormatBytes(totalBytes))
+		fmt.Printf("Total: %d files, %s\n", totalFiles, bytefmt.FormatBytes(totalBytes))
 	}
 
 	return nil

--- a/cmd/beaker/dataset/root.go
+++ b/cmd/beaker/dataset/root.go
@@ -37,4 +37,5 @@ func NewDatasetCmd(
 	newRenameCmd(cmd, o, config)
 	newStreamCmd(cmd, o, config)
 	newInspectCmd(cmd, o, config)
+	newListCmd(cmd, o, config)
 }

--- a/cmd/beaker/experiment/run.go
+++ b/cmd/beaker/experiment/run.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	yaml "gopkg.in/yaml.v2"
 


### PR DESCRIPTION
Help text:
```
$ beaker dataset ls -h
usage: beaker dataset ls [<flags>] <dataset> [<prefix>]

List files in a dataset.

Flags:
  -h, --help           Show context-sensitive help (also try --help-long and --help-man).
  -v, --version        Show application version.
      --debug          Print verbose stack traces on error.
      --addr="beaker.dev.allenai.org"  
                       Address of the Beaker service.
      --format=FORMAT  Output format

Args:
  <dataset>   Dataset name or ID
  [<prefix>]  Path prefix
```

Output is human readable by default:
```
$ beaker dataset ls ds_gkjpvk00jvsp files/fff
     10KiB  2019-03-19T23:34:30Z  files/fff1adc407242adb4097
    100KiB  2019-03-19T23:34:30Z  files/fff3a28889f47261bb12
     10KiB  2019-03-19T23:34:30Z  files/fff71ba7055bd435c1fe
     10KiB  2019-03-19T23:34:30Z  files/fffe044027d3605abd09
Total: 4 files, 130KiB
```

`--format json` outputs a JSON object for each file:
```
$ beaker dataset ls --format json ds_gkjpvk00jvsp files/fff
{"path":"files/fff1adc407242adb4097-10KiB","bytes":10240,"updated":1553038470289902000}
{"path":"files/fff3a28889f47261bb12-100KiB","bytes":102400,"updated":1553038470289903000}
{"path":"files/fff71ba7055bd435c1fe-10KiB","bytes":10240,"updated":1553038470289903000}
{"path":"files/fffe044027d3605abd09-10KiB","bytes":10240,"updated":1553038470289904000}
```