### PR TITLE
Add back the missing SearchImages function

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -151,3 +151,23 @@ func (h *ImageHandle) PatchPermissions(
 	defer safeClose(resp.Body)
 	return errorFromResponse(resp)
 }
+
+func (c *Client) SearchImages(
+	ctx context.Context,
+	searchOptions api.ImageSearchOptions,
+	page int,
+) ([]api.Image, error) {
+	query := url.Values{"page": {strconv.Itoa(page)}}
+	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/images/search", query, searchOptions)
+	if err != nil {
+		return nil, err
+	}
+	defer safeClose(resp.Body)
+
+	var body []api.Image
+	if err := parseResponse(resp, &body); err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}


### PR DESCRIPTION
When we were copying "blueprint" functions to "image" functions, looks like we forgot one. This PR adds back the missing "SearchImages" based on the "SearchBlueprint" implementation here: https://github.com/allenai/beaker/commit/ecc350d42706e253e26273e58c0dde7e52208386#diff-d89721205eb675cf8ae886fe0e8aad83L155

The endpoint on the Service API side is still there.