### PR TITLE
Sort datasets by created date

### DIFF
--- a/api/searchfield/dataset.go
+++ b/api/searchfield/dataset.go
@@ -3,6 +3,7 @@ package searchfield
 type Dataset string
 
 const (
+	DatasetCreated           Dataset = "created"
 	DatasetCommitted         Dataset = "committed"
 	DatasetCreatingUser      Dataset = "user"
 	DatasetDescription       Dataset = "description"


### PR DESCRIPTION
I wish we could sort datasets by creation date, not just committed date.

This change to the client is a start at supporting this, but the API needs to be changed too, because this returns a 400 `'created' is not a recognized dataset search field`:

```
POST /api/v3/datasets/search?page=0 HTTP/1.1
Host: beaker.org
Authorization: x
Beaker-Version: v20190301
Content-Type: application/json

{"sort_clauses":[{"field":"created","order":"descending"}],"filter_clauses":[{"field":"description","operator":"ctn","value":"x"}],"filter_combinator":"and","include_uncommitted":true}
```

Can someone update the API and then approve/merge this change?