### PR TITLE
allow uncommitted datasets

### DIFF
--- a/client/experiment.go
+++ b/client/experiment.go
@@ -18,13 +18,18 @@ type ExperimentHandle struct {
 	id     string
 }
 
-// CreateExperiment creates a new experiment with an optional name.
+// CreateExperiment creates a new experiment with an optional name. If force is true, then
+// Beaker is asked to admit the experiment even if it depends on uncommitted datasets.
 func (c *Client) CreateExperiment(
 	ctx context.Context,
 	spec api.ExperimentSpec,
 	name string,
+	force bool,
 ) (*ExperimentHandle, error) {
 	query := url.Values{"name": {name}}
+	if force {
+		query.Add("force", "true")
+	}
 	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/experiments", query, spec)
 	if err != nil {
 		return nil, err

--- a/client/experiment.go
+++ b/client/experiment.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -125,4 +126,24 @@ func (h *ExperimentHandle) PatchPermissions(
 	}
 	defer safeClose(resp.Body)
 	return errorFromResponse(resp)
+}
+
+func (c *Client) SearchExperiments(
+	ctx context.Context,
+	searchOptions api.ExperimentSearchOptions,
+	page int,
+) ([]api.Experiment, error) {
+	query := url.Values{"page": {strconv.Itoa(page)}}
+	resp, err := c.sendRequest(ctx, http.MethodPost, "/api/v3/experiments/search", query, searchOptions)
+	if err != nil {
+		return nil, err
+	}
+	defer safeClose(resp.Body)
+
+	var body []api.Experiment
+	if err := parseResponse(resp, &body); err != nil {
+		return nil, err
+	}
+
+	return body, nil
 }

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -20,6 +20,7 @@ type CreateOptions struct {
 	Name  string
 	Quiet bool
 	Org   string
+	Force bool
 }
 
 func newCreateCmd(
@@ -39,6 +40,7 @@ func newCreateCmd(
 	cmd.Flag("name", "Assign a name to the experiment").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created experiment's ID").Short('q').BoolVar(&opts.Quiet)
 	cmd.Flag("org", "Org that will own the created experiment").Short('o').StringVar(&opts.Org)
+	cmd.Flag("force", "Allow depending on uncommitted datasets").BoolVar(&opts.Force)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		var specFile io.Reader
@@ -109,7 +111,7 @@ func Create(
 	}
 	apiSpec.Organization = opts.Org
 
-	experiment, err := beaker.CreateExperiment(ctx, apiSpec, opts.Name)
+	experiment, err := beaker.CreateExperiment(ctx, apiSpec, opts.Name, opts.Force)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This exposes the "force" query arg that exists on the service's experiment creation API.