### PR TITLE
Tweak to permit trailing slash in address for configure command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -44,7 +44,8 @@ func NewClient(address string, userToken string) (*Client, error) {
 		return nil, err
 	}
 
-	if u.Path != "" || u.Opaque != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+	// First condition permits single trailing slash in url
+	if (u.Path != "" && u.Path != "/") || u.Opaque != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
 		return nil, errors.New("address must be base server address in the form [scheme://]host[:port]")
 	}
 


### PR DESCRIPTION
Ref: https://app.asana.com/0/366914398596019/883056111803235/f

When there is a single trailing slash, the field `u.Path` is set to "/". I changed the error behaviour so that if `u.Path` is set this way, then despite it being non-empty the client doesn't break.