### PR TITLE
Add a workspace flag to create for image, dataset, group and experiment

### DIFF
--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -22,6 +22,7 @@ type createOptions struct {
 	quiet       bool
 	source      string
 	org         string
+	workspace   string
 }
 
 func newCreateCmd(
@@ -45,7 +46,8 @@ func newCreateCmd(
 	cmd.Flag("desc", "Assign a description to the dataset").StringVar(&o.description)
 	cmd.Flag("name", "Assign a name to the dataset").Short('n').StringVar(&o.name)
 	cmd.Flag("quiet", "Only display created dataset's ID").Short('q').BoolVar(&o.quiet)
-	cmd.Flag("org", "Org that will own the created experiment").Short('o').StringVar(&o.org)
+	cmd.Flag("org", "Org that will own the created dataset").Short('o').StringVar(&o.org)
+	cmd.Flag("workspace", "Workspace that will own the created dataset").Short('w').StringVar(&o.workspace)
 	cmd.Arg("source", "Path to a file or directory containing the data").
 		Required().ExistingFileOrDirVar(&o.source)
 }
@@ -65,6 +67,7 @@ func (o *createOptions) run(beaker *beaker.Client) error {
 		Description:  o.description,
 		Organization: o.org,
 		FileHeap:     true,
+		Workspace:    o.workspace,
 	}
 	if !info.IsDir() {
 		// If uploading a single file, treat it as a single-file dataset.

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -18,10 +18,11 @@ import (
 
 // CreateOptions wraps options used to create an experiment.
 type CreateOptions struct {
-	Name  string
-	Quiet bool
-	Org   string
-	Force bool
+	Name      string
+	Quiet     bool
+	Org       string
+	Force     bool
+	Workspace string
 }
 
 func newCreateCmd(
@@ -41,6 +42,7 @@ func newCreateCmd(
 	cmd.Flag("name", "Assign a name to the experiment").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created experiment's ID").Short('q').BoolVar(&opts.Quiet)
 	cmd.Flag("org", "Org that will own the created experiment").Short('o').StringVar(&opts.Org)
+	cmd.Flag("workspace", "Workspace that will own the created experiment").Short('w').StringVar(&opts.Workspace)
 	cmd.Flag("force", "Allow depending on uncommitted datasets").BoolVar(&opts.Force)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -105,6 +107,7 @@ func Create(
 		return "", err
 	}
 	apiSpec.Organization = opts.Org
+	apiSpec.Workspace = opts.Workspace
 
 	experiment, err := beaker.CreateExperiment(ctx, apiSpec, opts.Name, opts.Force)
 	if err != nil {

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -19,6 +19,7 @@ type createOptions struct {
 	quiet       bool
 	org         string
 	experiments []string
+	workspace   string
 }
 
 func newCreateCmd(
@@ -42,7 +43,8 @@ func newCreateCmd(
 	cmd.Flag("desc", "Assign a description to the group").StringVar(&o.description)
 	cmd.Flag("name", "Assign a name to the group").Short('n').Required().StringVar(&o.name)
 	cmd.Flag("quiet", "Only display created group's ID").Short('q').BoolVar(&o.quiet)
-	cmd.Flag("org", "Org that will own the created experiment").Short('o').StringVar(&o.org)
+	cmd.Flag("org", "Org that will own the created group").Short('o').StringVar(&o.org)
+	cmd.Flag("workspace", "Workspace that will own the created group").Short('w').StringVar(&o.workspace)
 	cmd.Arg("experiment", "ID of experiment to add to the group").StringsVar(&o.experiments)
 }
 
@@ -52,6 +54,7 @@ func (o *createOptions) run(beaker *beaker.Client) error {
 		Description:  o.description,
 		Organization: o.org,
 		Experiments:  trimAndUnique(o.experiments),
+		Workspace:    o.workspace,
 	}
 	group, err := beaker.CreateGroup(context.TODO(), spec)
 	if err != nil {

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -27,6 +27,8 @@ type CreateOptions struct {
 	Description string
 	Name        string
 	Quiet       bool
+	Org         string
+	Workspace   string
 }
 
 func newCreateCmd(
@@ -41,6 +43,8 @@ func newCreateCmd(
 	cmd.Flag("desc", "Assign a description to the image").StringVar(&opts.Description)
 	cmd.Flag("name", "Assign a name to the image").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created image's ID").Short('q').BoolVar(&opts.Quiet)
+	cmd.Flag("org", "Org that will own the created image").Short('o').StringVar(&opts.Org)
+	cmd.Flag("workspace", "Workspace that will own the created image").Short('w').StringVar(&opts.Workspace)
 	cmd.Arg("image", "Docker image ID").Required().StringVar(image)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -79,9 +83,11 @@ func Create(
 	}
 
 	spec := api.ImageSpec{
-		Description: opts.Description,
-		ImageID:     dockerImage.ID,
-		ImageTag:    imageTag,
+		Description:  opts.Description,
+		ImageID:      dockerImage.ID,
+		ImageTag:     imageTag,
+		Workspace:    opts.Workspace,
+		Organization: opts.Org,
 	}
 	image, err := beaker.CreateImage(ctx, spec, opts.Name)
 	if err != nil {


### PR DESCRIPTION
This PR:

* Adds a workspace flag to the create operations for datasets, experiments, images and groups.
* Cleans up some language