### PR TITLE
create or use default workspaces if none provided

### DIFF
--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -1,5 +1,7 @@
 package config
 
+// TODO: Re-assess where this file should go when refactoring the client's package structure.
+
 import (
 	"context"
 	"fmt"
@@ -9,13 +11,15 @@ import (
 	api "github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
 	"github.com/fatih/color"
+
+	"github.com/allenai/beaker/config"
 )
 
 // EnsureDefaultWorkspace uses the configured default workspace if it is available.
 // Otherwise it falls back to a set of default workspaces, creating them if needed.
 func EnsureDefaultWorkspace(
 	client *beaker.Client,
-	config *Config,
+	config *config.Config,
 	org string,
 ) (string, error) {
 	ctx := context.TODO()

--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -4,13 +4,11 @@ package config
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path"
 
 	api "github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
-	"github.com/fatih/color"
 
 	"github.com/allenai/beaker/config"
 )
@@ -34,15 +32,15 @@ func EnsureDefaultWorkspace(
 		return "", err
 	}
 
-	// If an org isn't specified, use the "<author>/default" workspace.
-	// Otherwise, use the "<org>/<author>" workspace.
+	// If an org is specified, use the "<org>/<author>-default" workspace.
+	// Otherwise, use the "<author>/default" workspace.
 	var workspaceName string
 	var workspaceRef string
 	if org == "" {
 		workspaceName = "default"
 		workspaceRef = path.Join(author.Name, workspaceName)
 	} else {
-		workspaceName = author.Name
+		workspaceName = author.Name + "-default"
 		workspaceRef = path.Join(org, workspaceName)
 	}
 
@@ -60,6 +58,5 @@ func EnsureDefaultWorkspace(
 		return "", err
 	}
 
-	fmt.Printf("No workspace specified; using default workspace %s.\n", color.BlueString(workspaceRef))
 	return workspaceRef, nil
 }

--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
 
+	configCmd "github.com/allenai/beaker/cmd/beaker/config"
 	"github.com/allenai/beaker/config"
 )
 
@@ -41,7 +42,7 @@ func newCreateCmd(
 			o.org = cfg.DefaultOrg
 		}
 		if o.workspace == "" {
-			o.workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, o.org)
+			o.workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg, o.org)
 			if err != nil {
 				return err
 			}

--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -46,6 +46,9 @@ func newCreateCmd(
 			if err != nil {
 				return err
 			}
+			if !o.quiet {
+				fmt.Printf("Using workspace %s\n", color.BlueString(o.workspace))
+			}
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -28,20 +28,23 @@ type createOptions struct {
 func newCreateCmd(
 	parent *kingpin.CmdClause,
 	parentOpts *datasetOptions,
-	config *config.Config,
+	cfg *config.Config,
 ) {
 	o := &createOptions{}
 	cmd := parent.Command("create", "Create a new dataset")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.addr, cfg.UserToken)
 		if err != nil {
 			return err
 		}
 		if o.org == "" {
-			o.org = config.DefaultOrg
+			o.org = cfg.DefaultOrg
 		}
 		if o.workspace == "" {
-			o.workspace = config.DefaultWorkspace
+			o.workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, o.org)
+			if err != nil {
+				return err
+			}
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -28,7 +28,7 @@ type CreateOptions struct {
 func newCreateCmd(
 	parent *kingpin.CmdClause,
 	parentOpts *experimentOptions,
-	config *config.Config,
+	cfg *config.Config,
 ) {
 	opts := &CreateOptions{}
 	expandVars := new(bool)
@@ -56,17 +56,20 @@ func newCreateCmd(
 			return err
 		}
 
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.addr, cfg.UserToken)
 		if err != nil {
 			return err
 		}
 
 		if opts.Org == "" {
-			opts.Org = config.DefaultOrg
+			opts.Org = cfg.DefaultOrg
 		}
 
 		if opts.Workspace == "" {
-			opts.Workspace = config.DefaultWorkspace
+			opts.Workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, opts.Org)
+			if err != nil {
+				return err
+			}
 		}
 
 		_, err = Create(context.TODO(), os.Stdout, beaker, spec, opts)

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -13,6 +13,7 @@ import (
 
 	beaker "github.com/beaker/client/client"
 
+	configCmd "github.com/allenai/beaker/cmd/beaker/config"
 	"github.com/allenai/beaker/config"
 )
 
@@ -66,7 +67,7 @@ func newCreateCmd(
 		}
 
 		if opts.Workspace == "" {
-			opts.Workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, opts.Org)
+			opts.Workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg, opts.Org)
 			if err != nil {
 				return err
 			}

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -71,6 +71,9 @@ func newCreateCmd(
 			if err != nil {
 				return err
 			}
+			if !opts.Quiet {
+				fmt.Printf("Using workspace %s\n", color.BlueString(opts.Workspace))
+			}
 		}
 
 		_, err = Create(context.TODO(), os.Stdout, beaker, spec, opts)

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
 
+	configCmd "github.com/allenai/beaker/cmd/beaker/config"
 	"github.com/allenai/beaker/config"
 )
 
@@ -38,7 +39,7 @@ func newCreateCmd(
 			o.org = cfg.DefaultOrg
 		}
 		if o.workspace == "" {
-			o.workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, o.org)
+			o.workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg, o.org)
 			if err != nil {
 				return err
 			}

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -43,6 +43,9 @@ func newCreateCmd(
 			if err != nil {
 				return err
 			}
+			if !o.quiet {
+				fmt.Printf("Using workspace %s\n", color.BlueString(o.workspace))
+			}
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -25,20 +25,23 @@ type createOptions struct {
 func newCreateCmd(
 	parent *kingpin.CmdClause,
 	parentOpts *groupOptions,
-	config *config.Config,
+	cfg *config.Config,
 ) {
 	o := &createOptions{}
 	cmd := parent.Command("create", "Create a new experiment group")
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.addr, cfg.UserToken)
 		if err != nil {
 			return err
 		}
 		if o.org == "" {
-			o.org = config.DefaultOrg
+			o.org = cfg.DefaultOrg
 		}
 		if o.workspace == "" {
-			o.workspace = config.DefaultWorkspace
+			o.workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, o.org)
+			if err != nil {
+				return err
+			}
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -57,6 +57,9 @@ func newCreateCmd(
 			if err != nil {
 				return err
 			}
+			if !opts.Quiet {
+				fmt.Printf("Using workspace %s\n", color.BlueString(opts.Workspace))
+			}
 		}
 
 		_, err = Create(context.TODO(), os.Stdout, beaker, *image, opts)

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -33,7 +33,7 @@ type CreateOptions struct {
 func newCreateCmd(
 	parent *kingpin.CmdClause,
 	parentOpts *CmdOptions,
-	config *config.Config,
+	cfg *config.Config,
 ) {
 	opts := &CreateOptions{}
 	image := new(string)
@@ -46,13 +46,16 @@ func newCreateCmd(
 	cmd.Arg("image", "Docker image ID").Required().StringVar(image)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		beaker, err := beaker.NewClient(parentOpts.Addr, config.UserToken)
+		beaker, err := beaker.NewClient(parentOpts.Addr, cfg.UserToken)
 		if err != nil {
 			return err
 		}
 
 		if opts.Workspace == "" {
-			opts.Workspace = config.DefaultWorkspace
+			opts.Workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, cfg.DefaultOrg)
+			if err != nil {
+				return err
+			}
 		}
 
 		_, err = Create(context.TODO(), os.Stdout, beaker, *image, opts)

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
 
+	configCmd "github.com/allenai/beaker/cmd/beaker/config"
 	"github.com/allenai/beaker/config"
 )
 
@@ -52,7 +53,7 @@ func newCreateCmd(
 		}
 
 		if opts.Workspace == "" {
-			opts.Workspace, err = config.EnsureDefaultWorkspace(beaker, cfg, cfg.DefaultOrg)
+			opts.Workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg, cfg.DefaultOrg)
 			if err != nil {
 				return err
 			}

--- a/config/workspace.go
+++ b/config/workspace.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+
+	api "github.com/beaker/client/api"
+	beaker "github.com/beaker/client/client"
+	"github.com/fatih/color"
+)
+
+// EnsureDefaultWorkspace uses the configured default workspace if it is available.
+// Otherwise it falls back to a set of default workspaces, creating them if needed.
+func EnsureDefaultWorkspace(
+	client *beaker.Client,
+	config *Config,
+	org string,
+) (string, error) {
+	ctx := context.TODO()
+
+	// If the user configured a default workspace, use it.
+	if config.DefaultWorkspace != "" {
+		return config.DefaultWorkspace, nil
+	}
+
+	author, err := client.WhoAmI(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// If an org isn't specified, use the "<author>/default" workspace.
+	// Otherwise, use the "<org>/<author>" workspace.
+	var workspaceName string
+	var workspaceRef string
+	if org == "" {
+		workspaceName = "default"
+		workspaceRef = path.Join(author.Name, workspaceName)
+	} else {
+		workspaceName = author.Name
+		workspaceRef = path.Join(org, workspaceName)
+	}
+
+	if _, err = client.Workspace(ctx, workspaceRef); err != nil {
+		if apiErr, ok := err.(api.Error); ok {
+			if apiErr.Code == http.StatusNotFound {
+				if _, err = client.CreateWorkspace(ctx, api.WorkspaceSpec{
+					Name:         workspaceName,
+					Organization: org,
+				}); err != nil {
+					return "", err
+				}
+			}
+		}
+		return "", err
+	}
+
+	fmt.Printf("No workspace specified; using default workspace %s.\n", color.BlueString(workspaceRef))
+	return workspaceRef, nil
+}


### PR DESCRIPTION
The leaderboard requires users use the Beaker CLI to create images for the experiments they're going to run. Any change to the CLI or APIs requiring that a workspace be specified will introduce a new step to these leaderboard submissions that will likely be confusing to users who otherwise don't interact with Beaker.

I see two big pluses here:
1. This version of the CLI makes it impossible to create anything in Beaker without specifying a workspace.
2. Leaderboard users can keep using the tool the way they do today and don't need to be any wiser about Beaker's changes (they never interact with Beaker outside of the CLI for creating images, anyway).

This is a counter change to https://github.com/allenai/beaker/pull/125, which I realized would not work well with the leaderboard given the reasons above. IMHO the best solution is a bespoke CLI for the leaderboard that can completely abstract away Beaker, but that requires more time investment than I or the REVIZ team can commit at this moment.