### PR TITLE
Fix logic bug in error handling

### DIFF
--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -45,17 +45,16 @@ func EnsureDefaultWorkspace(
 	}
 
 	if _, err = client.Workspace(ctx, workspaceRef); err != nil {
-		if apiErr, ok := err.(api.Error); ok {
-			if apiErr.Code == http.StatusNotFound {
-				if _, err = client.CreateWorkspace(ctx, api.WorkspaceSpec{
-					Name:         workspaceName,
-					Organization: org,
-				}); err != nil {
-					return "", err
-				}
+		if apiErr, ok := err.(api.Error); ok && apiErr.Code == http.StatusNotFound {
+			if _, err = client.CreateWorkspace(ctx, api.WorkspaceSpec{
+				Name:         workspaceName,
+				Organization: org,
+			}); err != nil {
+				return "", err
 			}
+		} else {
+			return "", err
 		}
-		return "", err
 	}
 
 	return workspaceRef, nil


### PR DESCRIPTION
I copied this pattern from the code I added in the Leaderboard, and we discovered today that there's a bug in the error handling logic. If EnsureDefualtWorkspace is called when the workspace doesn't exist, we'd work our way to the CreateWorkspace call, and that call succeeds, but then the function would return at line 58 with values `"", nil`

This change modifies the logic to make sure that we only return in these cases:
1. A non-API error, or an API error that isn't a not found
2. Failure to create the workspace
3. The workspace now exists (either by the initial lookup or a successful create) and we return the reference and no error.