### PR TITLE
Fix beaker experiment run to honor workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ must be installed to take full advantage of Beaker.
    to create experiments.  You can either ask on #beaker-users or email experiment-team@allenai.org.
    Please include the email address associated with your Beaker account.
 
+   **NOTE**: If you recently signed up, you should already have the necessary permissions.
+
 2. Run your first experiment. The following example
    [counts words](https://beaker.org/bp/bp_qbjvcda1sed7) in the text
    of [Moby Dick](https://beaker.org/ds/ds_1hz9k6sgxi0a).
 
    ```bash
    beaker experiment run \
-     --name wordcount-moby \
      --image examples/wordcount \
      --source examples/moby:/input \
      --result-path /output

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ must be installed to take full advantage of Beaker.
      --result-path /output
    ```
 
+   **NOTE**: Add the `--dry-run` argument above to generate an experiment spec which is the building
+   blocks for specifying more complex options to beaker.
+
 ## Install Beaker CLI
 
 The most direct way to install Beaker is to download a

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ must be installed to take full advantage of Beaker.
    ```
 
    **NOTE**: Add the `--dry-run` argument above to generate an experiment spec which is the building
-   blocks for specifying more complex options to beaker.
+   blocks for specifying more complex options to beaker. See `beaker experiment create -h` for details.
 
 ## Install Beaker CLI
 

--- a/cmd/beaker/experiment/spec.go
+++ b/cmd/beaker/experiment/spec.go
@@ -88,10 +88,7 @@ func (d TaskDependency) ToAPI() api.TaskDependency {
 
 // TaskSpec contains all information necessary to create a new experiment on the host.
 type TaskSpec struct {
-	// (required) Blueprint describing the code to be run.
-	Blueprint string `yaml:"blueprint"`
-
-	// Image describing code to be run or name of the Docker image to run (deprecated).
+	// (required) Image describing code to be run
 	Image string `yaml:"image,omitempty"`
 
 	// (required) Container path in which experiment will save results.
@@ -132,13 +129,8 @@ func (s *TaskSpec) ToAPI() (*api.TaskSpec, error) {
 		return nil, err
 	}
 
-	image := s.Image
-	if image == "" {
-		image = s.Blueprint
-	}
-
 	return &api.TaskSpec{
-		Image:        image,
+		Image:        s.Image,
 		ResultPath:   s.ResultPath,
 		Description:  s.Description,
 		Arguments:    s.Arguments,


### PR DESCRIPTION
beaker run is still the simplest way to have users on-boarded and using beaker - especially when following https://github.com/allenai/beaker#beaker

I don't think its a good idea to deprecate/remove it, at least to the extent it can be used to run examples from the public `examples` workspace. I have added workspace support and simplified the image bootstrap support.