### PR TITLE
Fix tag normalization error on image pull

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5
 	github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591
-	github.com/docker/distribution v2.7.0+incompatible // indirect
+	github.com/docker/distribution v2.7.0+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect


### PR DESCRIPTION
Docker's `ImageTag` function returns an error on valid references if they're not in canonical form. For example: 

```bash
beaker image pull examples/wordcount friendly-name
```

The `friendly-name` in this example must be canonicalized to `docker.io/library/friendly-name`.