### PR TITLE
Bump beaker client and add cluster failure handling

### DIFF
--- a/cmd/beaker/cluster/create.go
+++ b/cmd/beaker/cluster/create.go
@@ -24,7 +24,7 @@ type createOptions struct {
 	size        int
 	preemptible bool
 	protected   bool
-	cpuCount    int
+	cpuCount    float64
 	gpuCount    int
 	gpuType     string
 	memory      string
@@ -48,7 +48,7 @@ func newCreateCmd(
 	cmd.Flag("max-size", "Maximum number of nodes").IntVar(&o.size)
 	cmd.Flag("preemptible", "Enable cheaper but more volatile nodes").BoolVar(&o.preemptible)
 	cmd.Flag("protected", "Mark cluster as protected - ADMINS ONLY").Hidden().BoolVar(&o.protected)
-	cmd.Flag("cpu-count", "Number of CPUs per node").IntVar(&o.cpuCount)
+	cmd.Flag("cpu-count", "Number of CPUs per node").FloatVar(&o.cpuCount)
 	cmd.Flag("gpu-count", "Number of GPUs per node").IntVar(&o.gpuCount)
 	cmd.Flag("gpu-type", "Type of GPU, e.g. p100").StringVar(&o.gpuType)
 	cmd.Flag("memory", "Memory limit per node, e.g. 6.5GiB").StringVar(&o.memory)
@@ -67,7 +67,7 @@ func (o *createOptions) run(beaker *beaker.Client) error {
 		Capacity:    o.size,
 		Preemptible: o.preemptible,
 		Protected:   o.protected,
-		Spec: api.NodeSpec{
+		Spec: api.NodeResources{
 			CPUCount: o.cpuCount,
 			GPUCount: o.gpuCount,
 			GPUType:  o.gpuType,
@@ -132,7 +132,7 @@ func (o *createOptions) run(beaker *beaker.Client) error {
 
 			case api.ClusterFailed:
 				fmt.Println(" failed")
-				return errors.New("please contact Beaker for assistance")
+				return errors.New(cluster.StatusMessage)
 
 			default:
 				fmt.Println(" failed")

--- a/cmd/beaker/config/test.go
+++ b/cmd/beaker/config/test.go
@@ -53,7 +53,7 @@ func newTestCmd(
 			fmt.Println("No default org set.")
 		} else {
 			fmt.Printf("Verifying default org: %q\n\n", cfg.DefaultOrg)
-			err = beaker.VerifyOrgExists(context.TODO(), cfg.DefaultOrg)
+			_, err := beaker.Organization(cfg.DefaultOrg).Get(context.TODO())
 			if err != nil {
 				fmt.Println("There was a problem verifying your default org.")
 				fmt.Println("Set the default organization in your config in the format `default_org: <org_name>`. Note that the name may be different from the name displayed in beaker UI.")

--- a/cmd/beaker/task/cancel.go
+++ b/cmd/beaker/task/cancel.go
@@ -36,11 +36,7 @@ func (o *cancelOptions) run(parentOpts *experimentOptions, userToken string) err
 	}
 
 	for _, id := range o.ids {
-		task, err := beaker.Task(ctx, id)
-		if err != nil {
-			return err
-		}
-
+		task := beaker.Task(id)
 		if err := task.Stop(ctx); err != nil {
 			// We want to cancel as many of the requested tasks as possible.
 			// Therefore we print to STDERR here instead of returning.

--- a/cmd/beaker/task/inspect.go
+++ b/cmd/beaker/task/inspect.go
@@ -39,12 +39,7 @@ func (o *inspectOptions) run(beaker *beaker.Client) error {
 
 	var tasks []*api.Task
 	for _, id := range o.ids {
-		task, err := beaker.Task(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		info, err := task.Get(ctx)
+		info, err := beaker.Task(id).Get(ctx)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.6 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5
+	github.com/beaker/client v0.0.0-20200401175853-58491e6f1673
 	github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591
 	github.com/docker/distribution v2.7.0+incompatible
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5 h1:sfKPLy8r6LFxdR3IOoteGuuSiqJTMOAfZW/ClAc93k8=
 github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
+github.com/beaker/client v0.0.0-20200401175853-58491e6f1673 h1:BfRDrwAf7vCTqyJ/CFdQosSmZBijKiXqh1nNrWvLazU=
+github.com/beaker/client v0.0.0-20200401175853-58491e6f1673/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
 github.com/beaker/fileheap v0.0.0-20190607174848-4d7ca2fc4416/go.mod h1:M14OgSGeIYOCxmkcdcDi6HP+Dd6fW0QZUaSWK6fNx9A=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591 h1:BKRHEopDd5dTFHRGB0dP1Xpon6z3LJciIyDuSf63+w4=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591/go.mod h1:6LpIYqPQ8c/lIzNI0LtQGFJceTbx15gdbFBCP7u5LMQ=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5 h1:sfKPLy8r6LFxdR3IOoteGuuSiqJTMOAfZW/ClAc93k8=
-github.com/beaker/client v0.0.0-20200129192138-6b8fdc9260d5/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
 github.com/beaker/client v0.0.0-20200401175853-58491e6f1673 h1:BfRDrwAf7vCTqyJ/CFdQosSmZBijKiXqh1nNrWvLazU=
 github.com/beaker/client v0.0.0-20200401175853-58491e6f1673/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
 github.com/beaker/fileheap v0.0.0-20190607174848-4d7ca2fc4416/go.mod h1:M14OgSGeIYOCxmkcdcDi6HP+Dd6fW0QZUaSWK6fNx9A=


### PR DESCRIPTION
Example usage:
```
./beaker cluster create --max-size=2 --memory=98GiB --gpu-type=v100 --gpu-count=1 ai2/vivekl-invalid
Cluster ai2/vivekl-invalid created (ID us_5q1tt6xs9mz3/01E4Y5PKS183K0P3Y914E6ZCGK)
Preparing cluster... failed
Error: failed to find candidate machine spec for cluster "ai2/vivekl-invalid":
	* n1-highmem: for GPU type 1X v100 max memory is 78 GiB and max CPU count is 12
	* n1-highcpu: n1-highcpu: no valid machine exists for the given combination of memory and CPU
	* n1-custom: must specify CPU to use a custom instance type
	* n1-standard: for GPU type 1X v100 max memory is 78 GiB and max CPU count is 12
```