### PR TITLE
Add alpha commands to support commit hooks and remote image build support

### DIFF
--- a/cmd/beaker/alpha/autobuild.go
+++ b/cmd/beaker/alpha/autobuild.go
@@ -1,0 +1,64 @@
+package alpha
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/allenai/beaker/cmd/beaker/alpha/hooks"
+)
+
+type autobuild struct {
+	workspace string
+}
+
+func newAutobuild(parent *kingpin.CmdClause) {
+	opts := &autobuild{}
+
+	a := parent.Command("auto-build", "Enable/disable autobuild on the cloud for this repo")
+	a.Flag("workspace", "workspace to associate image with").Short('w').Required().StringVar(&opts.workspace)
+	a.Action(func(c *kingpin.ParseContext) error {
+		topDir, err := hooks.GetTopDir()
+		if err != nil {
+			return err
+		}
+
+		if _, err := os.Stat(filepath.Join(topDir, "Dockerfile")); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("no Dockerfile detected: %w", err)
+			}
+			return fmt.Errorf("checking for Dockerfile: %w", err)
+		}
+
+		cfg := fmt.Sprintf(cloudbuildYaml, opts.workspace)
+		if err = ioutil.WriteFile(filepath.Join(topDir, "cloudbuild.yaml"), []byte(cfg), 0600); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+const cloudbuildYaml = `steps:
+- name: gcr.io/kaniko-project/executor
+  args:
+  - --destination=gcr.io/$PROJECT_ID/autobuild/$REPO_NAME:$SHORT_SHA
+  - --cache=true
+- name: gcr.io/cloud-builders/gcloud
+  entrypoint: 'bash'
+  args: [ '-c', 'echo "user_token: ` + "`gcloud secrets versions access latest --secret=beaker-token`\"" + ` >> beaker-config.yml' ]
+- name: 'gcr.io/cloud-builders/curl'
+  args: ['-L', '-O', 'https://github.com/allenai/beaker/releases/download/v20200430/beaker_linux.tar.gz']
+- name: 'ubuntu'
+  args: ['tar', '-xvzf', 'beaker_linux.tar.gz']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', 'gcr.io/$PROJECT_ID/autobuild/$REPO_NAME:$SHORT_SHA']
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: './beaker'
+  args: ['image', 'create', '-w', '%s', '-n', '$REPO_NAME-$SHORT_SHA', 'gcr.io/$PROJECT_ID/autobuild/$REPO_NAME:$SHORT_SHA']
+  env:
+  - 'BEAKER_CONFIG_FILE=beaker-config.yml'
+timeout: 3600s
+`

--- a/cmd/beaker/alpha/hooks/dataset_from_src.go
+++ b/cmd/beaker/alpha/hooks/dataset_from_src.go
@@ -1,0 +1,59 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"text/template"
+)
+
+type datasetFromSrc struct{}
+
+func (d *datasetFromSrc) EnableScriptlet() string {
+	return "${hook_dir}/dataset_from_src"
+}
+
+func (d *datasetFromSrc) Render(topDir string, opts *CommitHooks) error {
+	f, err := os.OpenFile(filepath.Join(topDir, ".git", "hooks", "dataset_from_src"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	directory := opts.datasetFromSrc.directory
+	if directory == "" {
+		directory = topDir
+	}
+	templateData := map[string]interface{}{
+		"Workspace":   opts.workspace,
+		"TopDir":      topDir,
+		"ProjectName": path.Base(topDir),
+		"Directory":   directory,
+	}
+
+	t, err := template.New("").Funcs(template.FuncMap{
+		"sanitize": sanitize,
+	}).Parse(datasetCreateScript)
+	if err != nil {
+		return err
+	}
+	if err = t.Execute(f, templateData); err != nil {
+		return fmt.Errorf("generating commit hook file: %w", err)
+	}
+
+	return nil
+}
+
+const (
+	datasetCreateScript = `#!/bin/sh
+# Commit hook installed by beaker alpha commit-hooks dataset-from-src
+
+hash=$(git rev-parse --short HEAD)
+pushd {{ .TopDir }} 2>&1 > /dev/null
+beaker dataset create {{ if .Workspace -}} -w {{ .Workspace }} {{ end -}} \
+	-n {{ .ProjectName | sanitize }}_$hash \
+	{{ .Directory }} 
+popd 2>&1 > /dev/null
+`
+)

--- a/cmd/beaker/alpha/hooks/git.go
+++ b/cmd/beaker/alpha/hooks/git.go
@@ -1,0 +1,21 @@
+package hooks
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetTopDir returns the absolute path to the base directory for the current repo or an
+// error if it fails to determine the top directory
+func GetTopDir() (string, error) {
+	var buf bytes.Buffer
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("resolving root directory for git repo: %w", err)
+	}
+	topDir := strings.TrimSpace(buf.String())
+	return topDir, nil
+}

--- a/cmd/beaker/alpha/hooks/image_build.go
+++ b/cmd/beaker/alpha/hooks/image_build.go
@@ -1,0 +1,58 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"text/template"
+)
+
+type imageBuild struct{}
+
+func (i *imageBuild) EnableScriptlet() string {
+	return "${hook_dir}/image_build"
+}
+
+func (i *imageBuild) Render(topDir string, opts *CommitHooks) error {
+	f, err := os.OpenFile(filepath.Join(topDir, ".git", "hooks", "image_build"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	templateData := map[string]interface{}{
+		"Workspace":          opts.workspace,
+		"TopDir":             topDir,
+		"ProjectName":        path.Base(topDir),
+		"RegisterWithBeaker": !opts.imageBuild.registerWithBeaker,
+	}
+
+	t, err := template.New("").Funcs(template.FuncMap{
+		"sanitize": sanitize,
+	}).Parse(imageBuildScript)
+	if err != nil {
+		return err
+	}
+	if err = t.Execute(f, templateData); err != nil {
+		return fmt.Errorf("generating commit hook file: %w", err)
+	}
+
+	return nil
+}
+
+const (
+	imageBuildScript = `#!/bin/sh
+# Commit hook installed by beaker alpha commit-hooks image-build
+
+hash=$(git rev-parse --short HEAD)
+pushd {{ .TopDir }} 2>&1 > /dev/null
+DOCKER_BUILDKIT=1 docker build . -t {{ .ProjectName }}:$hash
+{{ if not .RegisterWithBeaker }}
+beaker image create {{ if .Workspace -}} -w {{ .Workspace }} {{ end -}} \
+	-n {{ .ProjectName | sanitize }}_$hash \
+	{{ .ProjectName }}:$hash
+{{ end }}
+popd 2>&1 > /dev/null
+`
+)

--- a/cmd/beaker/alpha/hooks/root.go
+++ b/cmd/beaker/alpha/hooks/root.go
@@ -1,0 +1,190 @@
+package hooks
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// CommitHooks wraps options used in git hook management.
+type CommitHooks struct {
+	workspace  string
+	imageBuild struct {
+		registerWithBeaker bool
+	}
+	datasetFromSrc struct {
+		directory string
+	}
+	remove bool
+}
+
+type hook interface {
+	EnableScriptlet() string
+	Render(topDir string, opts *CommitHooks) error
+}
+
+func NewCommitHooks(app *kingpin.Application, parent *kingpin.CmdClause) {
+	opts := &CommitHooks{}
+	hooks := parent.Command("commit-hooks", "Manage git commit hooks for managing beaker images/datasets")
+	buildImgCmd := hooks.Command("build-image", "Build docker image on commit (and optionally register with beaker)")
+	buildImgCmd.Flag("register-with-beaker", "Registering the docker image with beaker").Short('b').BoolVar(&opts.imageBuild.registerWithBeaker)
+	buildImgCmd.Flag("remove", "Remove the commit hook").Short('r').BoolVar(&opts.remove)
+	buildImgCmd.Flag("workspace", "workspace to associate images and datasets with, uses default workspace if not specified").Short('w').StringVar(&opts.workspace)
+	// In theory, we can eliminate the need for this if github URLs could be exposed as datasets to beaker directly.
+	// This is still useful for local iteration (i.e. we suggest git commit but don't require a push).
+	datasetFromSrcCmd := hooks.Command("dataset-from-src", "Upload code as dataset to beaker")
+	datasetFromSrcCmd.Arg("directory", "Upload the directory in repo as dataset on commit. Defaults to the root directory of the repo").StringVar(&opts.datasetFromSrc.directory)
+	datasetFromSrcCmd.Flag("remove", "Remove the commit hook").Short('r').BoolVar(&opts.remove)
+	datasetFromSrcCmd.Flag("workspace", "workspace to associate images and datasets with, uses default workspace if not specified").Short('w').StringVar(&opts.workspace)
+	hooks.PreAction(func(c *kingpin.ParseContext) error {
+		// Add automatic help generation for the command group.
+		var helpSubcommands []string
+		hooks.Command("help", "Show help.").Hidden().Default().PreAction(func(c *kingpin.ParseContext) error {
+			fullCommand := append([]string{hooks.Model().Name}, helpSubcommands...)
+			app.Usage(fullCommand)
+			return nil
+		}).Arg("command", "Show help on command.").StringsVar(&helpSubcommands)
+		return nil
+	})
+	processHooks := func(curr hook) error {
+		topDir, err := GetTopDir()
+		if err != nil {
+			return err
+		}
+
+		if _, err := os.Stat(filepath.Join(topDir, "Dockerfile")); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("no Dockerfile detected: %w", err)
+			}
+			return fmt.Errorf("checking for Dockerfile: %w", err)
+		}
+
+		if err := exec.Command("docker", "-v").Run(); err != nil {
+			return fmt.Errorf("checking for docker installation: %w", err)
+		}
+
+		hookDir := filepath.Join(topDir, ".git", "hooks")
+		if err = os.MkdirAll(hookDir, 0700); err != nil {
+			return err
+		}
+
+		currHooks, err := loadHooks(topDir)
+		if err != nil {
+			return err
+		}
+
+		enabled := make(map[hook]bool)
+		for _, c := range currHooks {
+			enabled[c] = true
+		}
+		currHooks = append(currHooks, curr)
+		if enabled[curr] {
+			if opts.remove {
+				delete(enabled, curr)
+			}
+		} else {
+			enabled[curr] = true
+		}
+
+		for hook, _ := range enabled {
+			if err = hook.Render(topDir, opts); err != nil {
+				return err
+			}
+		}
+
+		f, err := os.OpenFile(filepath.Join(hookDir, "post-commit"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		t, err := template.New("").Parse(postCommitScript)
+		if err != nil {
+			return err
+		}
+
+		var hooks []hook
+		for h := range enabled {
+			hooks = append(hooks, h)
+		}
+		if err = t.Execute(f, hooks); err != nil {
+			return err
+		}
+
+		return nil
+	}
+	buildImgCmd.Action(func(c *kingpin.ParseContext) error {
+		return processHooks(&imageBuild{})
+	})
+	datasetFromSrcCmd.Action(func(c *kingpin.ParseContext) error {
+		return processHooks(&datasetFromSrc{})
+	})
+}
+
+func loadHooks(topDir string) ([]hook, error) {
+	imgBuild := &imageBuild{}
+	datasetFromSrc := &datasetFromSrc{}
+
+	scriptletMap := map[string]hook{
+		imgBuild.EnableScriptlet():       imgBuild,
+		datasetFromSrc.EnableScriptlet(): datasetFromSrc,
+	}
+	hookFile := filepath.Join(topDir, ".git", "hooks", "post-commit")
+	b, err := ioutil.ReadFile(hookFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var hooks []hook
+	buf := bytes.NewBuffer(b)
+	for {
+		l, err := buf.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if hook, ok := scriptletMap[strings.TrimSpace(l)]; ok {
+			hooks = append(hooks, hook)
+		}
+	}
+	return hooks, nil
+}
+
+func sanitize(identifier string) (string, error) {
+	if len(identifier) == 0 {
+		return identifier, nil
+	}
+	if identifier[0] == '-' {
+		identifier = identifier[1:]
+	}
+	reg, err := regexp.Compile("[^a-zA-Z0-9-_]+")
+	if err != nil {
+		return "", err
+	}
+	return reg.ReplaceAllString(identifier, "_"), nil
+}
+
+const (
+	postCommitScript = `#!/bin/sh
+
+hook_dir="$(dirname "$0")"
+
+{{- range . }}
+{{ .EnableScriptlet }}
+{{- end }}
+`
+)

--- a/cmd/beaker/alpha/root.go
+++ b/cmd/beaker/alpha/root.go
@@ -36,4 +36,5 @@ func NewAlphaCmd(
 	newTensorboardCmd(cmd, o, config)
 	newTuneCmd(cmd, o, config)
 	hooks.NewCommitHooks(parent, cmd)
+	newAutobuild(cmd)
 }

--- a/cmd/beaker/alpha/root.go
+++ b/cmd/beaker/alpha/root.go
@@ -3,6 +3,7 @@ package alpha
 import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/allenai/beaker/cmd/beaker/alpha/hooks"
 	"github.com/allenai/beaker/cmd/beaker/options"
 	"github.com/allenai/beaker/config"
 )
@@ -34,4 +35,5 @@ func NewAlphaCmd(
 	// Attach subcommands.
 	newTensorboardCmd(cmd, o, config)
 	newTuneCmd(cmd, o, config)
+	hooks.NewCommitHooks(parent, cmd)
 }


### PR DESCRIPTION
Adds:
1. commit hook to create docker image locally on commit and optionally upload to beaker
2. commit hook to create dataset. The use case here is to pull things out of the image and into datasets to speed up iteration time.
3. command to generate a cloud build config which can be leveraged to enable much faster build/push times for the beaker image. Note - the project still needs to be manually added to google cloud build for it to be used.

In support of https://github.com/allenai/bunsen/issues/8