### PR TITLE
Use beaker.org instead of api.beaker.org for default address

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 const (
 	addressKey       = "BEAKER_ADDR"
 	configPathKey    = "BEAKER_CONFIG_FILE"
-	defaultAddress   = "https://api.beaker.org"
+	defaultAddress   = "https://beaker.org"
 	beakerConfigFile = "config.yml"
 )
 


### PR DESCRIPTION
For new users, we seem to render experiment links with `defaultAddress` as the base which results in `https://api.beaker.org/ex/ex-blah` which 404s. `api` subdomain is really no longer relevant so removing it.