### PR TITLE
Support direct use of DockerHub images

### DIFF
--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -92,7 +92,7 @@ func Create(
 	// TODO: It would be far cleaner and more efficient to do this implicitly in the create request.
 	for i, exp := range spec.Tasks {
 		for j, mount := range exp.Spec.Mounts {
-			dataset, err := beaker.Dataset(ctx, mount.DatasetID)
+			dataset, err := beaker.Dataset(ctx, mount.Dataset)
 			if err != nil {
 				return "", err
 			}
@@ -101,7 +101,7 @@ func Create(
 			if err != nil {
 				return "", err
 			}
-			spec.Tasks[i].Spec.Mounts[j].DatasetID = ds.ID
+			spec.Tasks[i].Spec.Mounts[j].Dataset = ds.ID
 		}
 	}
 

--- a/cmd/beaker/experiment/run.go
+++ b/cmd/beaker/experiment/run.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/beaker/client/api"
 	beaker "github.com/beaker/client/client"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -172,8 +173,8 @@ func specFromArgs(args specArgs) (*ExperimentSpec, error) {
 			return nil, errors.Errorf("malformed source '%s': should be of the form 'source:target'", source)
 		}
 
-		spec.Mounts = append(spec.Mounts, DatasetMount{
-			DatasetID:     splitSource[0], // May be name or ID.
+		spec.Mounts = append(spec.Mounts, api.DatasetMount{
+			Dataset:       splitSource[0], // May be name or ID.
 			ContainerPath: splitSource[1],
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.6 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/beaker/client v0.0.0-20200601221240-5d1e1b25f2f2
+	github.com/beaker/client v0.0.0-20200611231145-29b1cfbe8386
 	github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591
 	github.com/docker/distribution v2.7.0+incompatible
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/beaker/client v0.0.0-20200601221240-5d1e1b25f2f2 h1:3igCS+vsgny2th9PReNeW3r/ueL8eJ2vYB1owv69b84=
-github.com/beaker/client v0.0.0-20200601221240-5d1e1b25f2f2/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
+github.com/beaker/client v0.0.0-20200611231145-29b1cfbe8386 h1:Cjte/2WzEeZ8TII9G6FNC6d20aVQIBZSieHRVvOyTX4=
+github.com/beaker/client v0.0.0-20200611231145-29b1cfbe8386/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
 github.com/beaker/fileheap v0.0.0-20190607174848-4d7ca2fc4416/go.mod h1:M14OgSGeIYOCxmkcdcDi6HP+Dd6fW0QZUaSWK6fNx9A=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591 h1:BKRHEopDd5dTFHRGB0dP1Xpon6z3LJciIyDuSf63+w4=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591/go.mod h1:6LpIYqPQ8c/lIzNI0LtQGFJceTbx15gdbFBCP7u5LMQ=


### PR DESCRIPTION
While updating the spec, I noticed some redundancy, so I removed duplicate structs.  We should eventually remove the remainder and use only the `api` package.