### PR TITLE
Remove support for experiment create force flag

### DIFF
--- a/cmd/beaker/alpha/tune.go
+++ b/cmd/beaker/alpha/tune.go
@@ -210,7 +210,7 @@ func runParameterSearch(
 		}
 
 		// TODO: Set a name?
-		experiment, err := beaker.CreateExperiment(ctx, spec, "", false, "normal")
+		experiment, err := beaker.CreateExperiment(ctx, spec, "", "normal")
 		if err != nil {
 			return experiments, err
 		}

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -32,7 +32,6 @@ const (
 type CreateOptions struct {
 	Name     string
 	Quiet    bool
-	Force    bool
 	Priority string
 }
 
@@ -50,7 +49,6 @@ func newCreateCmd(
 	cmd.Flag("name", "Assign a name to the experiment").Short('n').StringVar(&opts.Name)
 	cmd.Flag("quiet", "Only display created experiment's ID").Short('q').BoolVar(&opts.Quiet)
 	cmd.Flag("workspace", "Workspace where the experiment will be placed").Short('w').StringVar(&workspace)
-	cmd.Flag("force", "Allow depending on uncommitted datasets").BoolVar(&opts.Force)
 	cmd.Flag("priority", "Assign an execution priority to the experiment").Short('p').EnumVar(&opts.Priority, low, normal, high)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -107,7 +105,7 @@ func Create(
 		opts = &CreateOptions{}
 	}
 
-	experiment, err := beaker.CreateExperiment(ctx, *spec, opts.Name, opts.Force, opts.Priority)
+	experiment, err := beaker.CreateExperiment(ctx, *spec, opts.Name, opts.Priority)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.6 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/beaker/client v0.0.0-20200804190614-6ce943c94f2a
+	github.com/beaker/client v0.0.0-20200812174545-684a6feb5688
 	github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591
 	github.com/docker/distribution v2.7.0+incompatible
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/beaker/client v0.0.0-20200804190614-6ce943c94f2a h1:QuRJGwm1xCf2c8SXOJNwJibsBbfumCssnM8TbUpD2Jg=
-github.com/beaker/client v0.0.0-20200804190614-6ce943c94f2a/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
+github.com/beaker/client v0.0.0-20200812174545-684a6feb5688 h1:GnVWkT/JPZKp85vrb4TojKLlo8CTlivwVHywHmO8Vrw=
+github.com/beaker/client v0.0.0-20200812174545-684a6feb5688/go.mod h1:i/WETkBXW1/lALGxPY13aI9cQFoJantgUm+g8kx3DOQ=
 github.com/beaker/fileheap v0.0.0-20190607174848-4d7ca2fc4416/go.mod h1:M14OgSGeIYOCxmkcdcDi6HP+Dd6fW0QZUaSWK6fNx9A=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591 h1:BKRHEopDd5dTFHRGB0dP1Xpon6z3LJciIyDuSf63+w4=
 github.com/beaker/fileheap v0.0.0-20200106234808-5c201f881591/go.mod h1:6LpIYqPQ8c/lIzNI0LtQGFJceTbx15gdbFBCP7u5LMQ=


### PR DESCRIPTION
This flag was inconsistently applied and rarely used.  We've opted to remove it to simplify the API, rather than changing its behavior.