### PR TITLE
Require workspace

### DIFF
--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -38,7 +38,7 @@ func EnsureWorkspace(
 		if apiErr, ok := err.(api.Error); ok && apiErr.Code == http.StatusNotFound {
 			parts := strings.Split(workspaceRef, "/")
 			if len(parts) != 2 {
-				return "", errors.New("workspace must be formatted like '<organization>/<name>'")
+				return "", errors.New("workspace must be formatted like '<account>/<name>'")
 			}
 
 			if _, err = client.CreateWorkspace(ctx, api.WorkspaceSpec{

--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -16,7 +16,7 @@ import (
 
 // EnsureWorkspace ensures that workspaceRef exists or that the default workspace
 // exists if workspaceRef is empty.
-// Returns errWorkspaceNotProvided if workspaceRef and the default workspace are empty.
+// Returns an error if workspaceRef and the default workspace are empty.
 func EnsureWorkspace(
 	client *beaker.Client,
 	config *config.Config,

--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -14,10 +14,6 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-var errWorkspaceNotProvided = errors.New(`workspace not provided, either:
-1. Pass the --workspace flag
-2. Configure a default workspace with 'beaker config set default_workspace <workspace>'`)
-
 // EnsureWorkspaceExists ensures that workspaceRef exists or that the default workspace
 // exists if workspaceRef is empty.
 // Returns errWorkspaceNotProvided if workspaceRef and the default workspace are empty.
@@ -30,7 +26,9 @@ func EnsureWorkspaceExists(
 
 	if workspaceRef == "" {
 		if config.DefaultWorkspace == "" {
-			return "", errWorkspaceNotProvided
+			return "", errors.New(`workspace not provided, either:
+1. Pass the --workspace flag
+2. Configure a default workspace with 'beaker config set default_workspace <workspace>'`)
 		}
 		workspaceRef = config.DefaultWorkspace
 	}

--- a/cmd/beaker/config/workspace.go
+++ b/cmd/beaker/config/workspace.go
@@ -14,10 +14,10 @@ import (
 	"github.com/allenai/beaker/config"
 )
 
-// EnsureWorkspaceExists ensures that workspaceRef exists or that the default workspace
+// EnsureWorkspace ensures that workspaceRef exists or that the default workspace
 // exists if workspaceRef is empty.
 // Returns errWorkspaceNotProvided if workspaceRef and the default workspace are empty.
-func EnsureWorkspaceExists(
+func EnsureWorkspace(
 	client *beaker.Client,
 	config *config.Config,
 	workspaceRef string,

--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -36,7 +36,7 @@ func newCreateCmd(
 		if err != nil {
 			return err
 		}
-		if o.workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, o.workspace); err != nil {
+		if o.workspace, err = configCmd.EnsureWorkspace(beaker, cfg, o.workspace); err != nil {
 			return err
 		}
 		return o.run(beaker)

--- a/cmd/beaker/dataset/create.go
+++ b/cmd/beaker/dataset/create.go
@@ -36,14 +36,8 @@ func newCreateCmd(
 		if err != nil {
 			return err
 		}
-		if o.workspace == "" {
-			o.workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg)
-			if err != nil {
-				return err
-			}
-			if !o.quiet {
-				fmt.Printf("Using workspace %s\n", color.BlueString(o.workspace))
-			}
+		if o.workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, o.workspace); err != nil {
+			return err
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -63,7 +63,7 @@ func newCreateCmd(
 			return err
 		}
 
-		if workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, workspace); err != nil {
+		if workspace, err = configCmd.EnsureWorkspace(beaker, cfg, workspace); err != nil {
 			return err
 		}
 

--- a/cmd/beaker/experiment/create.go
+++ b/cmd/beaker/experiment/create.go
@@ -63,14 +63,8 @@ func newCreateCmd(
 			return err
 		}
 
-		// Find a default workspace if there's no explicit argument.
-		if workspace == "" {
-			if workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg); err != nil {
-				return err
-			}
-			if !opts.Quiet {
-				fmt.Printf("Using workspace %s\n", color.BlueString(workspace))
-			}
+		if workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, workspace); err != nil {
+			return err
 		}
 
 		rawSpec, err := readSpec(specFile)

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -33,14 +33,8 @@ func newCreateCmd(
 		if err != nil {
 			return err
 		}
-		if o.workspace == "" {
-			o.workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg)
-			if err != nil {
-				return err
-			}
-			if !o.quiet {
-				fmt.Printf("Using workspace %s\n", color.BlueString(o.workspace))
-			}
+		if o.workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, o.workspace); err != nil {
+			return err
 		}
 		return o.run(beaker)
 	})

--- a/cmd/beaker/group/create.go
+++ b/cmd/beaker/group/create.go
@@ -33,7 +33,7 @@ func newCreateCmd(
 		if err != nil {
 			return err
 		}
-		if o.workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, o.workspace); err != nil {
+		if o.workspace, err = configCmd.EnsureWorkspace(beaker, cfg, o.workspace); err != nil {
 			return err
 		}
 		return o.run(beaker)

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -51,7 +51,7 @@ func newCreateCmd(
 			return err
 		}
 
-		if opts.Workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, opts.Workspace); err != nil {
+		if opts.Workspace, err = configCmd.EnsureWorkspace(beaker, cfg, opts.Workspace); err != nil {
 			return err
 		}
 

--- a/cmd/beaker/image/create.go
+++ b/cmd/beaker/image/create.go
@@ -51,14 +51,8 @@ func newCreateCmd(
 			return err
 		}
 
-		if opts.Workspace == "" {
-			opts.Workspace, err = configCmd.EnsureDefaultWorkspace(beaker, cfg)
-			if err != nil {
-				return err
-			}
-			if !opts.Quiet {
-				fmt.Printf("Using workspace %s\n", color.BlueString(opts.Workspace))
-			}
+		if opts.Workspace, err = configCmd.EnsureWorkspaceExists(beaker, cfg, opts.Workspace); err != nil {
+			return err
 		}
 
 		_, err = Create(context.TODO(), os.Stdout, beaker, *image, opts)


### PR DESCRIPTION
This makes workspace required when creating datasets, experiments, groups, and images.

Workspace can be passed with the `--workspace` flag or set in the configuration file. If the workspace does not exist, it is created. Previously, the workspace was only created automatically if it was not set in the configuration file or passed explicitly.