### PR TITLE
Change all required flags to arguments

### DIFF
--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -204,20 +204,16 @@ func newExperimentRenameCommand() *cobra.Command {
 
 func newExperimentResumeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resume",
+		Use:   "resume <experiment>",
 		Short: "Resume a preempted experiment and return the experiment ID for the new experiment",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(1),
 	}
 
-	// TODO: This should be an argument not a flag, also confusing that we have --experiment-name and --name
-	// which is also an experiment name.
-	var experimentToResume string
 	var name string
-	cmd.Flags().StringVarP(&experimentToResume, "experiment-name", "e", "", "Experiment to resume")
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Assign a name to the experiment")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new experiment")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		experiment, err := beaker.ResumeExperiment(ctx, experimentToResume, name)
+		experiment, err := beaker.ResumeExperiment(ctx, args[0], name)
 		if err != nil {
 			return err
 		}

--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -35,7 +35,7 @@ func newExperimentCommand() *cobra.Command {
 
 func newExperimentCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <spec file>",
+		Use:   "create <spec-file>",
 		Short: "Create a new experiment",
 		Args:  cobra.ExactArgs(1),
 	}

--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -35,23 +35,20 @@ func newExperimentCommand() *cobra.Command {
 
 func newExperimentCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create -f <spec file>",
+		Use:   "create <spec file>",
 		Short: "Create a new experiment",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(1),
 	}
 
-	var specPath string
 	var name string
 	var workspace string
 	var priority string
-	// TODO Weird that this is a required flag, should be an argument instead.
-	cmd.Flags().StringVarP(&specPath, "file", "f", "", "Load experiment spec from a file")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Assign a name to the experiment")
 	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Workspace where the experiment will be placed")
 	cmd.Flags().StringVarP(&priority, "priority", "p", "", "Assign an execution priority to the experiment")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		specFile, err := openPath(specPath)
+		specFile, err := openPath(args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/beaker/group.go
+++ b/cmd/beaker/group.go
@@ -53,25 +53,27 @@ func newGroupAddCommand() *cobra.Command {
 
 func newGroupCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <experiment?>",
+		Use:   "create <name> <experiment...>",
 		Short: "Create a new experiment group",
-		Args:  cobra.ArbitraryArgs,
+		Args:  cobra.MinimumNArgs(1),
 	}
 
 	var description string
-	var name string
 	var workspace string
 	cmd.Flags().StringVar(&description, "desc", "", "Group description")
-	// TODO Required flag should be an argument instead.
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Group name")
 	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Group workspace")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		var err error
+		if workspace, err = ensureWorkspace(workspace); err != nil {
+			return err
+		}
+
 		spec := api.GroupSpec{
-			Name:        name,
+			Name:        args[0],
 			Description: description,
 			Workspace:   workspace,
-			Experiments: trimAndUnique(args),
+			Experiments: trimAndUnique(args[1:]),
 		}
 		group, err := beaker.CreateGroup(ctx, spec)
 		if err != nil {

--- a/cmd/beaker/secret.go
+++ b/cmd/beaker/secret.go
@@ -23,114 +23,94 @@ func newSecretCommand() *cobra.Command {
 }
 
 func newSecretDeleteCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "delete <secret>",
+	return &cobra.Command{
+		Use:   "delete <workspace> <secret>",
 		Short: "Permanently delete a secret",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workspace, err := beaker.Workspace(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			return workspace.DeleteSecret(ctx, args[1])
+		},
 	}
-
-	var workspace string
-	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Secret workspace")
-
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		workspace, err := beaker.Workspace(ctx, workspace)
-		if err != nil {
-			return err
-		}
-
-		return workspace.DeleteSecret(ctx, args[0])
-	}
-	return cmd
 }
 
 func newSecretListCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "list",
+	return &cobra.Command{
+		Use:   "list <workspace>",
 		Short: "List the metadata of all secrets in a workspace",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workspace, err := beaker.Workspace(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			secrets, err := workspace.ListSecrets(ctx)
+			if err != nil {
+				return err
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			const rowFormat = "%s\t%s\t%s\n"
+			fmt.Fprintf(w, rowFormat, "NAME", "CREATED", "UPDATED")
+			for _, secret := range secrets {
+				fmt.Fprintf(w, rowFormat,
+					secret.Name,
+					secret.Created.Format(time.RFC3339),
+					secret.Updated.Format(time.RFC3339))
+			}
+			return w.Flush()
+		},
 	}
-
-	var workspace string
-	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Secret workspace")
-
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		workspace, err := beaker.Workspace(ctx, workspace)
-		if err != nil {
-			return err
-		}
-
-		secrets, err := workspace.ListSecrets(ctx)
-		if err != nil {
-			return err
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		const rowFormat = "%s\t%s\t%s\n"
-		fmt.Fprintf(w, rowFormat, "NAME", "CREATED", "UPDATED")
-		for _, secret := range secrets {
-			fmt.Fprintf(w, rowFormat,
-				secret.Name,
-				secret.Created.Format(time.RFC3339),
-				secret.Updated.Format(time.RFC3339))
-		}
-		return w.Flush()
-	}
-	return cmd
 }
 
 func newSecretReadCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "read <secret>",
+	return &cobra.Command{
+		Use:   "read <workspace> <secret>",
 		Short: "Read the value of a secret",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workspace, err := beaker.Workspace(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			secret, err := workspace.ReadSecret(ctx, args[1])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s", secret)
+			return nil
+		},
 	}
-
-	var workspace string
-	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Secret workspace")
-
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		workspace, err := beaker.Workspace(ctx, workspace)
-		if err != nil {
-			return err
-		}
-
-		secret, err := workspace.ReadSecret(ctx, args[0])
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%s", secret)
-		return nil
-	}
-	return cmd
 }
 
 func newSecretWriteCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "write <secret> <value?>",
+	return &cobra.Command{
+		Use:   "write <workspace> <secret> <value?>",
 		Short: "Write a new secret or update an existing secret",
-		Args:  cobra.RangeArgs(1, 2),
-	}
-
-	var workspace string
-	cmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Secret workspace")
-
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		workspace, err := beaker.Workspace(ctx, workspace)
-		if err != nil {
-			return err
-		}
-
-		var value []byte
-		if len(args) == 1 {
-			if value, err = ioutil.ReadAll(os.Stdin); err != nil {
+		Args:  cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workspace, err := beaker.Workspace(ctx, args[0])
+			if err != nil {
 				return err
 			}
-		} else {
-			value = []byte(args[1])
-		}
 
-		_, err = workspace.PutSecret(ctx, args[0], value)
-		return err
+			var value []byte
+			if len(args) == 2 {
+				if value, err = ioutil.ReadAll(os.Stdin); err != nil {
+					return err
+				}
+			} else {
+				value = []byte(args[2])
+			}
+
+			_, err = workspace.PutSecret(ctx, args[1], value)
+			return err
+		},
 	}
-	return cmd
 }


### PR DESCRIPTION
Breaking changes:
 - `beaker experiment resume --experiment-name <experiment>` changed to `beaker experiment resume <experiment>`
 - `beaker experiment create --file <spec file>` changed to `beaker experiment create <spec file>`
 - `beaker group create --name <name> <experiment...>` changed to `beaker group create <name> <experiment...>`
 - `beaker secret <command> --workspace <workspace>` changed to `beaker secret <command> <workspace>`