### PR TITLE
Add execution and task log commands

### DIFF
--- a/cmd/beaker/execution.go
+++ b/cmd/beaker/execution.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/beaker/client/api"
+	"github.com/spf13/cobra"
+)
+
+func newExecutionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "execution <command>",
+		Short: "Manage executions",
+	}
+	cmd.AddCommand(newExecutionInspectCommand())
+	cmd.AddCommand(newExecutionLogsCommand())
+	return cmd
+}
+
+func newExecutionInspectCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <execution...>",
+		Short: "Display detailed information about one or more executions",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var executions []*api.Execution
+			for _, id := range args {
+				info, err := beaker.Execution(id).Get(ctx)
+				if err != nil {
+					return err
+				}
+
+				executions = append(executions, info)
+			}
+
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "    ")
+			return encoder.Encode(executions)
+		},
+	}
+}
+
+func newExecutionLogsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logs <execution>",
+		Short: "Fetch execution logs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printExecutionLogs(args[0])
+		},
+	}
+}
+
+func printExecutionLogs(executionID string) error {
+	logs, err := beaker.Execution(executionID).GetLogs(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(os.Stdout, logs)
+	return err
+}

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -63,6 +63,7 @@ func main() {
 	root.AddCommand(newClusterCommand())
 	root.AddCommand(newConfigCommand())
 	root.AddCommand(newDatasetCommand())
+	root.AddCommand(newExecutionCommand())
 	root.AddCommand(newExperimentCommand())
 	root.AddCommand(newGroupCommand())
 	root.AddCommand(newImageCommand())

--- a/cmd/beaker/task.go
+++ b/cmd/beaker/task.go
@@ -14,6 +14,7 @@ func newTaskCommand() *cobra.Command {
 		Short: "Manage tasks",
 	}
 	cmd.AddCommand(newTaskInspectCommand())
+	cmd.AddCommand(newTaskLogsCommand())
 	return cmd
 }
 
@@ -36,6 +37,23 @@ func newTaskInspectCommand() *cobra.Command {
 			encoder := json.NewEncoder(os.Stdout)
 			encoder.SetIndent("", "    ")
 			return encoder.Encode(tasks)
+		},
+	}
+}
+
+func newTaskLogsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logs <task>",
+		Short: "Fetch logs for the most recent execution of a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			task, err := beaker.Task(args[0]).Get(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Most recent execution is last.
+			return printExecutionLogs(task.Executions[len(task.Executions)-1].ID)
 		},
 	}
 }

--- a/cmd/beaker/task.go
+++ b/cmd/beaker/task.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/beaker/client/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +51,10 @@ func newTaskLogsCommand() *cobra.Command {
 			task, err := beaker.Task(args[0]).Get(ctx)
 			if err != nil {
 				return err
+			}
+
+			if len(task.Executions) == 0 {
+				return errors.Errorf("task has no executions")
 			}
 
 			// Most recent execution is last.


### PR DESCRIPTION
Adds:
 - `beaker execution inspect <execution>`
 - `beaker execution logs <execution>`
 - `beaker task logs <task>`

I decided to keep the log commands simple. They just fetch the entire log and further processing can be done with other tools. Our API doesn't really support anything besides getting the entire log so we're not losing efficiency here. 