### PR TITLE
Add cluster and node commands

### DIFF
--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/beaker/client/api"
@@ -149,10 +147,7 @@ func newClusterInspectCommand() *cobra.Command {
 				clusters = append(clusters, info)
 			}
 
-			// TODO: Print this in a more human-friendly way, and include node summary.
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(clusters)
+			return printJSON(clusters)
 		},
 	}
 }
@@ -185,17 +180,17 @@ func newClusterListCommand() *cobra.Command {
 
 			switch format {
 			case formatJSON:
-				encoder := json.NewEncoder(os.Stdout)
-				encoder.SetIndent("", "    ")
-				return encoder.Encode(clusters)
+				return printJSON(clusters)
 			default:
-				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-				const rowFormat = "%s\n"
-				fmt.Fprintf(w, rowFormat, "NAME")
-				for _, cluster := range clusters {
-					fmt.Fprintf(w, rowFormat, cluster.Name)
+				if err := printTableRow("NAME"); err != nil {
+					return err
 				}
-				return w.Flush()
+				for _, cluster := range clusters {
+					if err := printTableRow(cluster.Name); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 		},
 	}

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -249,15 +249,15 @@ func newClusterListCommand() *cobra.Command {
 			for _, cluster := range clusters {
 				var (
 					gpuType  string
-					gpuCount string
-					cpuCount string
+					gpuCount int
+					cpuCount float64
 					memory   string
 				)
 				if cluster.NodeShape != nil {
-					gpuType = fmt.Sprintf("%v", cluster.NodeShape.GPUType)
-					gpuCount = fmt.Sprintf("%v", cluster.NodeShape.GPUCount)
-					cpuCount = fmt.Sprintf("%v", cluster.NodeShape.CPUCount)
-					memory = fmt.Sprintf("%v", cluster.NodeShape.Memory)
+					gpuType = cluster.NodeShape.GPUType
+					gpuCount = cluster.NodeShape.GPUCount
+					cpuCount = cluster.NodeShape.CPUCount
+					memory = cluster.NodeShape.Memory
 				}
 				if err := printTableRow(
 					cluster.Name,

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -144,41 +144,7 @@ func newClusterExecutionsCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			switch format {
-			case formatJSON:
-				return printJSON(executions)
-			default:
-				if err := printTableRow(
-					"ID",
-					"TASK",
-					"NAME",
-					"NODE",
-					"CPU COUNT",
-					"GPU COUNT",
-					"MEMORY",
-					"PRIORITY",
-					"STATUS",
-				); err != nil {
-					return err
-				}
-				for _, execution := range executions {
-					if err := printTableRow(
-						execution.ID,
-						execution.Task,
-						execution.Spec.Name,
-						execution.Node,
-						execution.Limits.CPUCount,
-						execution.Limits.GPUCount,
-						execution.Limits.Memory,
-						execution.Priority,
-						executionStatus(execution.State),
-					); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
+			return printExecutions(executions)
 		},
 	}
 }
@@ -333,10 +299,15 @@ func newClusterNodesCommand() *cobra.Command {
 					"GPU COUNT",
 					"GPU TYPE",
 					"MEMORY",
+					"CORDONED",
 				); err != nil {
 					return err
 				}
 				for _, node := range nodes {
+					var cordoned string
+					if node.Cordoned != nil {
+						cordoned = "true"
+					}
 					if err := printTableRow(
 						node.ID,
 						node.Hostname,
@@ -345,6 +316,7 @@ func newClusterNodesCommand() *cobra.Command {
 						node.Limits.GPUCount,
 						node.Limits.GPUType,
 						node.Limits.Memory,
+						cordoned,
 					); err != nil {
 						return err
 					}

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -293,7 +293,6 @@ func newClusterNodesCommand() *cobra.Command {
 				if err := printTableRow(
 					"ID",
 					"HOSTNAME",
-					"CREATED",
 					"CPU COUNT",
 					"GPU COUNT",
 					"GPU TYPE",
@@ -310,7 +309,6 @@ func newClusterNodesCommand() *cobra.Command {
 					if err := printTableRow(
 						node.ID,
 						node.Hostname,
-						node.Created,
 						node.Limits.CPUCount,
 						node.Limits.GPUCount,
 						node.Limits.GPUType,

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -243,6 +243,7 @@ func newClusterListCommand() *cobra.Command {
 				"GPU COUNT",
 				"CPU COUNT",
 				"MEMORY",
+				"AUTOSCALE",
 			); err != nil {
 				return err
 			}
@@ -265,6 +266,7 @@ func newClusterListCommand() *cobra.Command {
 					gpuCount,
 					cpuCount,
 					memory,
+					cluster.Autoscale,
 				); err != nil {
 					return err
 				}

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -182,11 +182,35 @@ func newClusterListCommand() *cobra.Command {
 			case formatJSON:
 				return printJSON(clusters)
 			default:
-				if err := printTableRow("NAME"); err != nil {
+				if err := printTableRow(
+					"NAME",
+					"GPU TYPE",
+					"GPU COUNT",
+					"CPU COUNT",
+					"MEMORY",
+				); err != nil {
 					return err
 				}
 				for _, cluster := range clusters {
-					if err := printTableRow(cluster.Name); err != nil {
+					var (
+						gpuType  string
+						gpuCount string
+						cpuCount string
+						memory   string
+					)
+					if cluster.NodeShape != nil {
+						gpuType = fmt.Sprintf("%v", cluster.NodeShape.GPUType)
+						gpuCount = fmt.Sprintf("%v", cluster.NodeShape.GPUCount)
+						cpuCount = fmt.Sprintf("%v", cluster.NodeShape.CPUCount)
+						memory = fmt.Sprintf("%v", cluster.NodeShape.Memory)
+					}
+					if err := printTableRow(
+						cluster.Name,
+						gpuType,
+						gpuCount,
+						cpuCount,
+						memory,
+					); err != nil {
 						return err
 					}
 				}

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -152,6 +152,7 @@ func newClusterExecutionsCommand() *cobra.Command {
 				if err := printTableRow(
 					"ID",
 					"TASK",
+					"NAME",
 					"NODE",
 					"CPU COUNT",
 					"GPU COUNT",
@@ -165,6 +166,7 @@ func newClusterExecutionsCommand() *cobra.Command {
 					if err := printTableRow(
 						execution.ID,
 						execution.Task,
+						execution.Spec.Name,
 						execution.Node,
 						execution.Limits.CPUCount,
 						execution.Limits.GPUCount,

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -298,14 +298,14 @@ func newClusterNodesCommand() *cobra.Command {
 					"GPU COUNT",
 					"GPU TYPE",
 					"MEMORY",
-					"CORDONED",
+					"STATUS",
 				); err != nil {
 					return err
 				}
 				for _, node := range nodes {
-					var cordoned string
+					status := "ok"
 					if node.Cordoned != nil {
-						cordoned = "true"
+						status = "cordoned"
 					}
 					if err := printTableRow(
 						node.ID,
@@ -315,7 +315,7 @@ func newClusterNodesCommand() *cobra.Command {
 						node.Limits.GPUCount,
 						node.Limits.GPUType,
 						node.Limits.Memory,
-						cordoned,
+						status,
 					); err != nil {
 						return err
 					}

--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -135,52 +135,69 @@ func newClusterCreateCommand() *cobra.Command {
 }
 
 func newClusterExecutionsCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "executions <cluster>",
 		Short: "List executions in a cluster",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			executions, err := beaker.Cluster(args[0]).ListExecutions(ctx, nil)
-			if err != nil {
+	}
+
+	var scheduled bool
+	var unscheduled bool
+	cmd.Flags().BoolVar(&scheduled, "scheduled", false, "Only show scheduled executions")
+	cmd.Flags().BoolVar(&unscheduled, "unscheduled", false, "Only show unscheduled executions")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if scheduled && unscheduled {
+			return fmt.Errorf("only one of --scheduled and --unscheduled may be set")
+		}
+
+		var scheduledOpt *bool
+		if scheduled || unscheduled {
+			scheduledOpt = &scheduled
+		}
+		executions, err := beaker.Cluster(args[0]).ListExecutions(ctx, &client.ExecutionFilters{
+			Scheduled: scheduledOpt,
+		})
+		if err != nil {
+			return err
+		}
+
+		switch format {
+		case formatJSON:
+			return printJSON(executions)
+		default:
+			if err := printTableRow(
+				"ID",
+				"TASK",
+				"NAME",
+				"NODE",
+				"CPU COUNT",
+				"GPU COUNT",
+				"MEMORY",
+				"PRIORITY",
+				"STATUS",
+			); err != nil {
 				return err
 			}
-
-			switch format {
-			case formatJSON:
-				return printJSON(executions)
-			default:
+			for _, execution := range executions {
 				if err := printTableRow(
-					"ID",
-					"TASK",
-					"NAME",
-					"NODE",
-					"CPU COUNT",
-					"GPU COUNT",
-					"MEMORY",
-					"PRIORITY",
-					"STATUS",
+					execution.ID,
+					execution.Task,
+					execution.Spec.Name,
+					execution.Node,
+					execution.Limits.CPUCount,
+					execution.Limits.GPUCount,
+					execution.Limits.Memory,
+					execution.Priority,
+					executionStatus(execution.State),
 				); err != nil {
 					return err
 				}
-				for _, execution := range executions {
-					if err := printTableRow(
-						execution.ID,
-						execution.Task,
-						execution.Spec.Name,
-						execution.Node,
-						execution.Limits.CPUCount,
-						execution.Limits.GPUCount,
-						execution.Limits.Memory,
-						execution.Priority,
-						executionStatus(execution.State),
-					); err != nil {
-						return err
-					}
-				}
-				return nil
 			}
-		},
+			return nil
+		}
 	}
+	return cmd
 }
 
 func executionStatus(state api.ExecutionState) string {

--- a/cmd/beaker/dataset.go
+++ b/cmd/beaker/dataset.go
@@ -198,10 +198,7 @@ func newDatasetInspectCommand() *cobra.Command {
 
 				datasets = append(datasets, detail{*info})
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(datasets)
+			return printJSON(datasets)
 		},
 	}
 }

--- a/cmd/beaker/execution.go
+++ b/cmd/beaker/execution.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"os"
 
@@ -34,10 +33,7 @@ func newExecutionInspectCommand() *cobra.Command {
 
 				executions = append(executions, info)
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(executions)
+			return printJSON(executions)
 		},
 	}
 }

--- a/cmd/beaker/execution.go
+++ b/cmd/beaker/execution.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/beaker/client/api"
+	"github.com/spf13/cobra"
+)
+
+func newExecutionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "execution <command>",
+		Short: "Manage executions",
+	}
+	cmd.AddCommand(newExecutionInspectCommand())
+	cmd.AddCommand(newExecutionLogsCommand())
+	return cmd
+}
+
+func newExecutionInspectCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <execution...>",
+		Short: "Display detailed information about one or more executions",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var executions []*api.Execution
+			for _, id := range args {
+				info, err := beaker.Execution(id).Get(ctx)
+				if err != nil {
+					return err
+				}
+
+				executions = append(executions, info)
+			}
+
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "    ")
+			return encoder.Encode(executions)
+		},
+	}
+}
+
+func newExecutionLogsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logs <execution>",
+		Short: "Fetch execution logs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printExecutionLogs(args[0])
+		},
+	}
+}
+
+func printExecutionLogs(executionID string) error {
+	logs, err := beaker.Execution(executionID).GetLogs(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(os.Stdout, logs)
+	return err
+}

--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -160,10 +159,7 @@ func newExperimentInspectCommand() *cobra.Command {
 
 				experiments = append(experiments, exp)
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(experiments)
+			return printJSON(experiments)
 		},
 	}
 }

--- a/cmd/beaker/group.go
+++ b/cmd/beaker/group.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/beaker/client/api"
@@ -152,10 +150,7 @@ func newGroupInspectCommand() *cobra.Command {
 
 			groups = append(groups, detail{*info, experiments})
 		}
-
-		encoder := json.NewEncoder(os.Stdout)
-		encoder.SetIndent("", "    ")
-		return encoder.Encode(groups)
+		return printJSON(groups)
 	}
 	return cmd
 }

--- a/cmd/beaker/image.go
+++ b/cmd/beaker/image.go
@@ -179,10 +179,7 @@ func newImageInspectCommand() *cobra.Command {
 
 				images = append(images, exp)
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(images)
+			return printJSON(images)
 		},
 	}
 }

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -91,6 +91,7 @@ func main() {
 	root.AddCommand(newExperimentCommand())
 	root.AddCommand(newGroupCommand())
 	root.AddCommand(newImageCommand())
+	root.AddCommand(newNodeCommand())
 	root.AddCommand(newSecretCommand())
 	root.AddCommand(newTaskCommand())
 	root.AddCommand(newWorkspaceCommand())

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/allenai/beaker/config"
 	"github.com/beaker/client/api"
@@ -32,7 +34,25 @@ const (
 	formatJSON = "json"
 )
 
+var jsonOut *json.Encoder
+var tableOut *tabwriter.Writer
+
+func printJSON(v interface{}) error {
+	return jsonOut.Encode(v)
+}
+
+func printTableRow(cells ...string) error {
+	_, err := fmt.Fprintln(tableOut, strings.Join(cells, "\t"))
+	return err
+}
+
 func main() {
+	jsonOut = json.NewEncoder(os.Stdout)
+	jsonOut.SetIndent("", "    ")
+
+	tableOut = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer tableOut.Flush()
+
 	var cancel context.CancelFunc
 	ctx, cancel = withSignal(context.Background())
 	defer cancel()

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -63,6 +63,7 @@ func main() {
 	root.AddCommand(newClusterCommand())
 	root.AddCommand(newConfigCommand())
 	root.AddCommand(newDatasetCommand())
+	root.AddCommand(newExecutionCommand())
 	root.AddCommand(newExperimentCommand())
 	root.AddCommand(newGroupCommand())
 	root.AddCommand(newImageCommand())

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -41,8 +41,12 @@ func printJSON(v interface{}) error {
 	return jsonOut.Encode(v)
 }
 
-func printTableRow(cells ...string) error {
-	_, err := fmt.Fprintln(tableOut, strings.Join(cells, "\t"))
+func printTableRow(cells ...interface{}) error {
+	var cellStrings []string
+	for _, cell := range cells {
+		cellStrings = append(cellStrings, fmt.Sprintf("%v", cell))
+	}
+	_, err := fmt.Fprintln(tableOut, strings.Join(cellStrings, "\t"))
 	return err
 }
 

--- a/cmd/beaker/node.go
+++ b/cmd/beaker/node.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/beaker/client/api"
+	"github.com/spf13/cobra"
+)
+
+func newNodeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node <command>",
+		Short: "Manage nodes",
+	}
+	cmd.AddCommand(newNodeCordonCommand())
+	cmd.AddCommand(newNodeExecutionsCommand())
+	cmd.AddCommand(newNodeUncordonCommand())
+	return cmd
+}
+
+func newNodeCordonCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cordon <node>",
+		Short: "Cordon a node preventing it from running new executions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cordoned := true
+			return beaker.Node(args[0]).Patch(ctx, &api.NodePatchSpec{
+				Cordoned: &cordoned,
+			})
+		},
+	}
+}
+
+func newNodeExecutionsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "executions <node>",
+		Short: "Cordon a node preventing it from running new executions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executions, err := beaker.Node(args[0]).ListExecutions(ctx)
+			if err != nil {
+				return err
+			}
+			return printExecutions(executions.Data)
+		},
+	}
+}
+
+func newNodeUncordonCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uncordon <node>",
+		Short: "Uncordon a node allowing it to run new executions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cordoned := false
+			return beaker.Node(args[0]).Patch(ctx, &api.NodePatchSpec{
+				Cordoned: &cordoned,
+			})
+		},
+	}
+}

--- a/cmd/beaker/node.go
+++ b/cmd/beaker/node.go
@@ -33,7 +33,7 @@ func newNodeCordonCommand() *cobra.Command {
 func newNodeExecutionsCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "executions <node>",
-		Short: "Cordon a node preventing it from running new executions",
+		Short: "List the executions of a node",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			executions, err := beaker.Node(args[0]).ListExecutions(ctx)

--- a/cmd/beaker/secret.go
+++ b/cmd/beaker/secret.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -54,16 +53,19 @@ func newSecretListCommand() *cobra.Command {
 				return err
 			}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			const rowFormat = "%s\t%s\t%s\n"
-			fmt.Fprintf(w, rowFormat, "NAME", "CREATED", "UPDATED")
+			if err := printTableRow("NAME", "CREATED", "UPDATED"); err != nil {
+				return err
+			}
 			for _, secret := range secrets {
-				fmt.Fprintf(w, rowFormat,
+				if err := printTableRow(
 					secret.Name,
 					secret.Created.Format(time.RFC3339),
-					secret.Updated.Format(time.RFC3339))
+					secret.Updated.Format(time.RFC3339),
+				); err != nil {
+					return err
+				}
 			}
-			return w.Flush()
+			return nil
 		},
 	}
 }

--- a/cmd/beaker/task.go
+++ b/cmd/beaker/task.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
-
 	"github.com/beaker/client/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -34,10 +31,7 @@ func newTaskInspectCommand() *cobra.Command {
 
 				tasks = append(tasks, info)
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(tasks)
+			return printJSON(tasks)
 		},
 	}
 }

--- a/cmd/beaker/workspace.go
+++ b/cmd/beaker/workspace.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/beaker/client/api"
 	"github.com/fatih/color"
@@ -99,10 +97,7 @@ func newWorkspaceInspectCommand() *cobra.Command {
 
 				workspaces = append(workspaces, exp)
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "    ")
-			return encoder.Encode(workspaces)
+			return printJSON(workspaces)
 		},
 	}
 }


### PR DESCRIPTION
Standardized JSON and table formatting and added commands for managing clusters.

## Cluster List

```
$ beaker cluster list ai2 --cloud  
NAME                                GPU TYPE  GPU COUNT  CPU COUNT  MEMORY
ai2/gpu-healthcheck                 p100      1          1          3.75 GiB
ai2/cpu-healthcheck                           0          1          3.75 GiB
ai2/ronan_aclcluster_gpu            v100      4          2          8.00 GiB
ai2/ronan_largemem_cpu                        0          32         208.00 GiB
ai2/aflite_experiments_swabha                 0          32         208.00 GiB
ai2/aristo_extraction               v100      1          8          52.00 GiB
ai2/s2-tldr                         v100      4          32         208.00 GiB
ai2/s2-tldr-8x                      v100      8          80         512.00 GiB
ai2/evaluation                                0          10         50.00 GiB
ai2/shared-p100-1x-16x-preem        p100      1          16         104.00 GiB
ai2/shared-p100-1x-16x              p100      1          16         104.00 GiB
ai2/shared-p100-4x-16x              p100      4          16         104.00 GiB
ai2/shared-p100-4x-16x-preem        p100      4          16         104.00 GiB
ai2/shared-v100-4x-16x              v100      4          16         104.00 GiB
ai2/shared-v100-4x-16x-preem        v100      4          16         104.00 GiB
ai2/shared-v100-8x-16x-preem        v100      8          16         104.00 GiB
ai2/shared-v100-8x-16x              v100      8          16         104.00 GiB
ai2/shared-cpu-only-16x-preem                 0          16         104.00 GiB
ai2/shared-cpu-only-16x                       0          16         104.00 GiB
ai2/shared-p100-4x-32x-preem        p100      4          32         208.00 GiB
ai2/shared-p100-4x-32x              p100      4          32         208.00 GiB
ai2/shared-cpu-only-32x-preem                 0          32         208.00 GiB
ai2/shared-cpu-only-32x                       0          32         208.00 GiB
ai2/shared-cpu-only-4x-preem                  0          4          26.00 GiB
ai2/shared-cpu-only-4x                        0          4          26.00 GiB
ai2/shared-v100-1x-8x               v100      1          8          52.00 GiB
ai2/shared-v100-1x-8x-preem         v100      1          8          52.00 GiB
ai2/shared-cpu-only-8x-preem                  0          8          52.00 GiB
ai2/shared-cpu-only-8x                        0          8          52.00 GiB
ai2/ckarenz                                   0          1          3.75 GiB
ai2/swabhas_aflite_v2                         0          64         57.60 GiB
ai2/aflite_swabhas_largermem                  0          80         512.00 GiB
ai2/t4-1                            t4        1          4          3.60 GiB
ai2/t4-4                            t4        4          20         128.00 GiB
ai2/t4-1-more-mem                   t4        2          4          3.60 GiB
ai2/t4-1x-mem                       t4        1          16         104.00 GiB
ai2/t4-2x-mem                       t4        2          32         208.00 GiB
ai2/example-cluster                           0          1          3.75 GiB
ai2/mnist-cluster                             0          1          3.75 GiB
ai2/mnist-cluster-2                           0          1          3.75 GiB
ai2/mnist-cluster-3                 p100      1          1          3.75 GiB
ai2/jack_clean_HowTo100M_asr_large  k80       1          2          13.00 GiB
ai2/jack_4xcpu_large                          0          4          26.00 GiB
```

## Cluster Executions

```
$ beaker cluster executions ai2/on-prem-ai2-server
ID                          TASK             NAME                NODE                        CPU COUNT  GPU COUNT  MEMORY  PRIORITY  STATUS
01EWDSVJKDJ9KXRDKVDD90S7KZ  tk_5ewmrd37hm4f  fine-tune-lot-wiki  01EWBQ4A7DMHAN423SP94VX3J5  7.5        1          62GiB   normal    running
01EWDSVWHSJPS25MJKS04XJ473  tk_z7wv47nhx1pt  fine-tune-lot-wiki  01ESRSQ7GCBVHDPXK671NFT564  7.5        1          62GiB   normal    running
01EWE24CQNFAY9270EJKKBF5YD  tk_0xgbx2m0ty4n                      01EWBQ4A7DMHAN423SP94VX3J5  7.5        1          62GiB   normal    running
```

## Cluster Nodes

```
$ beaker cluster nodes ai2/on-prem-ai2-server
ID                          HOSTNAME     CREATED                               CPU COUNT  GPU COUNT  GPU TYPE         MEMORY  CORDONED
01ESRSQ7GCBVHDPXK671NFT564  ai2-server1  2020-12-17 16:49:52.653442 +0000 UTC  60         8          Quadro RTX 8000  496GiB  
01EWBQ4A7DMHAN423SP94VX3J5  ai2-server2  2021-01-18 21:41:33.550863 +0000 UTC  45         6          Quadro RTX 8000  372GiB
```

## Node Executions

```
$ beaker node executions 01ESRSQ7GCBVHDPXK671NFT564
ID                          TASK             NAME                NODE                        CPU COUNT  GPU COUNT  MEMORY  PRIORITY  STATUS
01EWDSVWHSJPS25MJKS04XJ473  tk_z7wv47nhx1pt  fine-tune-lot-wiki  01ESRSQ7GCBVHDPXK671NFT564  7.5        1          62GiB   normal    running
```

## Node Cordon

```
$ beaker node cordon 01ESRSQ7GCBVHDPXK671NFT564
```

## Node Uncordon

```
$ beaker node uncordon 01ESRSQ7GCBVHDPXK671NFT564
```
