### PR TITLE
Prompt for login on missing or invalid token

### DIFF
--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -178,8 +178,8 @@ func login() error {
 	}
 	loginURL.Path = path.Join(loginURL.Path, "user")
 
-	fmt.Println("You are not logged in to Beaker. Please visit", loginURL.String())
-	fmt.Print("Then enter your user token: ")
+	fmt.Println("You are not logged in. To log in, find your user token here:", loginURL.String())
+	fmt.Print("Enter your user token: ")
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		input, err := reader.ReadString('\n')

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -178,7 +178,10 @@ func login() error {
 	}
 	loginURL.Path = path.Join(loginURL.Path, "user")
 
-	fmt.Println("You are not logged in. To log in, find your user token here:", loginURL.String())
+	fmt.Println(
+		"You are not logged in. To log in, find your user token here:",
+		color.BlueString(loginURL.String()),
+	)
 	fmt.Print("Enter your user token: ")
 	reader := bufio.NewReader(os.Stdin)
 	for {

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"text/tabwriter"
 
@@ -58,6 +61,11 @@ func main() {
 			var err error
 			if beakerConfig, err = config.New(); err != nil {
 				return err
+			}
+			if beakerConfig.UserToken == "" {
+				if err := login(); err != nil {
+					return err
+				}
 			}
 
 			beaker, err = client.NewClient(
@@ -152,4 +160,42 @@ func withSignal(parent context.Context) (context.Context, context.CancelFunc) {
 		signal.Stop(sigChan)
 		cancel()
 	}
+}
+
+// login prompts the user for an authentication token, validates it,
+// and writes it to the configuration file.
+func login() error {
+	loginURL, err := url.Parse(beakerConfig.BeakerAddress)
+	if err != nil {
+		return err
+	}
+	loginURL.Path = path.Join(loginURL.Path, "user")
+
+	fmt.Println("You are not logged in to Beaker. Please visit", loginURL.String())
+	fmt.Print("Then enter your user token: ")
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		beakerConfig.UserToken = strings.TrimSuffix(input, "\n")
+
+		beaker, err = client.NewClient(
+			beakerConfig.BeakerAddress,
+			beakerConfig.UserToken,
+		)
+		if err != nil {
+			return err
+		}
+		user, err := beaker.WhoAmI(ctx)
+		if err != nil {
+			fmt.Print("Invalid user token, please try again: ")
+			continue
+		}
+
+		fmt.Printf("Successfully logged in as %q\n\n", user.Name)
+		break
+	}
+	return config.WriteConfig(beakerConfig, config.GetFilePath())
 }

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -189,7 +189,7 @@ func login() error {
 		if err != nil {
 			return err
 		}
-		beakerConfig.UserToken = strings.TrimSuffix(input, "\n")
+		beakerConfig.UserToken = strings.TrimSpace(input)
 
 		beaker, err = client.NewClient(
 			beakerConfig.BeakerAddress,

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -91,7 +91,14 @@ func main() {
 	root.AddCommand(newTaskCommand())
 	root.AddCommand(newWorkspaceCommand())
 
-	if err := root.Execute(); err != nil {
+	err := root.Execute()
+	if err != nil && err.Error() == "invalid authentication token" {
+		err = login()
+		if err == nil {
+			err = root.Execute()
+		}
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s %+v\n", color.RedString("Error:"), err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Makes the CLI prompt for a user token if the token is missing or invalid. 

```
You are not logged in. To log in, find your user token here: https://beaker.org/user
Enter your user token: this-is-a-fake-token
Successfully logged in as "lane"
```