### PR TITLE
Rename inspect commands to get

### DIFF
--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -21,7 +21,7 @@ func newClusterCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newClusterCreateCommand())
 	cmd.AddCommand(newClusterExecutionsCommand())
-	cmd.AddCommand(newClusterInspectCommand())
+	cmd.AddCommand(newClusterGetCommand())
 	cmd.AddCommand(newClusterListCommand())
 	cmd.AddCommand(newClusterNodesCommand())
 	cmd.AddCommand(newClusterTerminateCommand())
@@ -153,11 +153,12 @@ func newClusterExecutionsCommand() *cobra.Command {
 	}
 }
 
-func newClusterInspectCommand() *cobra.Command {
+func newClusterGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <cluster...>",
-		Short: "Display detailed information about one or more clusters",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <cluster...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more clusters",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var clusters []api.Cluster
 			for _, id := range args {

--- a/cmd/beaker/dataset.go
+++ b/cmd/beaker/dataset.go
@@ -23,7 +23,7 @@ func newDatasetCommand() *cobra.Command {
 	cmd.AddCommand(newDatasetCreateCommand())
 	cmd.AddCommand(newDatasetDeleteCommand())
 	cmd.AddCommand(newDatasetFetchCommand())
-	cmd.AddCommand(newDatasetInspectCommand())
+	cmd.AddCommand(newDatasetGetCommand())
 	cmd.AddCommand(newDatasetLsCommand())
 	cmd.AddCommand(newDatasetRenameCommand())
 	cmd.AddCommand(newDatasetSizeCommand())
@@ -199,11 +199,12 @@ func newDatasetFetchCommand() *cobra.Command {
 	return cmd
 }
 
-func newDatasetInspectCommand() *cobra.Command {
+func newDatasetGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <dataset...>",
-		Short: "Display detailed information about one or more datasets",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <dataset...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more datasets",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var datasets []api.Dataset
 			for _, name := range args {

--- a/cmd/beaker/execution.go
+++ b/cmd/beaker/execution.go
@@ -13,17 +13,18 @@ func newExecutionCommand() *cobra.Command {
 		Use:   "execution <command>",
 		Short: "Manage executions",
 	}
-	cmd.AddCommand(newExecutionInspectCommand())
+	cmd.AddCommand(newExecutionGetCommand())
 	cmd.AddCommand(newExecutionLogsCommand())
 	cmd.AddCommand(newExecutionResultsCommand())
 	return cmd
 }
 
-func newExecutionInspectCommand() *cobra.Command {
+func newExecutionGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <execution...>",
-		Short: "Display detailed information about one or more executions",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <execution...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more executions",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var executions []api.Execution
 			for _, id := range args {

--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -27,7 +27,7 @@ func newExperimentCommand() *cobra.Command {
 	cmd.AddCommand(newExperimentDeleteCommand())
 	cmd.AddCommand(newExperimentExecutionsCommand())
 	cmd.AddCommand(newExperimentGroupsCommand())
-	cmd.AddCommand(newExperimentInspectCommand())
+	cmd.AddCommand(newExperimentGetCommand())
 	cmd.AddCommand(newExperimentRenameCommand())
 	cmd.AddCommand(newExperimentResumeCommand())
 	cmd.AddCommand(newExperimentSpecCommand())
@@ -202,11 +202,12 @@ func newExperimentGroupsCommand() *cobra.Command {
 	}
 }
 
-func newExperimentInspectCommand() *cobra.Command {
+func newExperimentGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <experiment...>",
-		Short: "Display detailed information about one or more experiments",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <experiment...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more experiments",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var experiments []api.Experiment
 			for _, name := range args {

--- a/cmd/beaker/group.go
+++ b/cmd/beaker/group.go
@@ -19,7 +19,7 @@ func newGroupCommand() *cobra.Command {
 	cmd.AddCommand(newGroupDeleteCommand())
 	cmd.AddCommand(newGroupExecutionsCommand())
 	cmd.AddCommand(newGroupExperimentsCommand())
-	cmd.AddCommand(newGroupInspectCommand())
+	cmd.AddCommand(newGroupGetCommand())
 	cmd.AddCommand(newGroupRemoveCommand())
 	cmd.AddCommand(newGroupRenameCommand())
 	cmd.AddCommand(newGroupTasksCommand())
@@ -186,11 +186,12 @@ func newGroupExperimentsCommand() *cobra.Command {
 	}
 }
 
-func newGroupInspectCommand() *cobra.Command {
+func newGroupGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <group...>",
-		Short: "Display detailed information about one or more groups",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <group...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more groups",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var groups []api.Group
 			for _, name := range args {

--- a/cmd/beaker/image.go
+++ b/cmd/beaker/image.go
@@ -26,7 +26,7 @@ func newImageCommand() *cobra.Command {
 	cmd.AddCommand(newImageCommitCommand())
 	cmd.AddCommand(newImageCreateCommand())
 	cmd.AddCommand(newImageDeleteCommand())
-	cmd.AddCommand(newImageInspectCommand())
+	cmd.AddCommand(newImageGetCommand())
 	cmd.AddCommand(newImagePullCommand())
 	cmd.AddCommand(newImageRenameCommand())
 	return cmd
@@ -185,11 +185,12 @@ func newImageDeleteCommand() *cobra.Command {
 	}
 }
 
-func newImageInspectCommand() *cobra.Command {
+func newImageGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <image...>",
-		Short: "Display detailed information about one or more images",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <image...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more images",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var images []api.Image
 			for _, name := range args {

--- a/cmd/beaker/node.go
+++ b/cmd/beaker/node.go
@@ -13,7 +13,7 @@ func newNodeCommand() *cobra.Command {
 	cmd.AddCommand(newNodeCordonCommand())
 	cmd.AddCommand(newNodeDeleteCommand())
 	cmd.AddCommand(newNodeExecutionsCommand())
-	cmd.AddCommand(newNodeInspectCommand())
+	cmd.AddCommand(newNodeGetCommand())
 	cmd.AddCommand(newNodeUncordonCommand())
 	return cmd
 }
@@ -58,11 +58,12 @@ func newNodeExecutionsCommand() *cobra.Command {
 	}
 }
 
-func newNodeInspectCommand() *cobra.Command {
+func newNodeGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <node...>",
-		Short: "Display detailed information about one or more nodes",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <node...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more nodes",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var nodes []api.Node
 			for _, id := range args {

--- a/cmd/beaker/organization.go
+++ b/cmd/beaker/organization.go
@@ -11,7 +11,7 @@ func newOrganizationCommand() *cobra.Command {
 		Short: "Manage organizations",
 	}
 	cmd.AddCommand(newOrganizationCreateCommand())
-	cmd.AddCommand(newOrganizationInspectCommand())
+	cmd.AddCommand(newOrganizationGetCommand())
 	cmd.AddCommand(newOrganizationListCommand())
 	cmd.AddCommand(newOrganizationMembersCommand())
 	return cmd
@@ -52,11 +52,12 @@ func newOrganizationCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func newOrganizationInspectCommand() *cobra.Command {
+func newOrganizationGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <organization...>",
-		Short: "Display detailed information about one or more organizations",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <organization...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more organizations",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var orgs []api.Organization
 			for _, name := range args {
@@ -103,7 +104,7 @@ func newOrganizationMembersCommand() *cobra.Command {
 		Short: "Manage organization membership",
 	}
 	cmd.AddCommand(newOrganizationMemberAddCommand())
-	cmd.AddCommand(newOrganizationMemberInspectCommand())
+	cmd.AddCommand(newOrganizationMemberGetCommand())
 	cmd.AddCommand(newOrganizationMemberListCommand())
 	cmd.AddCommand(newOrganizationMemberRemoveCommand())
 	return cmd
@@ -125,11 +126,12 @@ func newOrganizationMemberAddCommand() *cobra.Command {
 	return cmd
 }
 
-func newOrganizationMemberInspectCommand() *cobra.Command {
+func newOrganizationMemberGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <organization> <member...>",
-		Short: "Display detailed information about one or more organization members",
-		Args:  cobra.MinimumNArgs(2),
+		Use:     "get <organization> <member...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more organization members",
+		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var members []api.OrgMembership
 			for _, name := range args[1:] {

--- a/cmd/beaker/task.go
+++ b/cmd/beaker/task.go
@@ -12,7 +12,7 @@ func newTaskCommand() *cobra.Command {
 		Short: "Manage tasks",
 	}
 	cmd.AddCommand(newTaskExecutionsCommand())
-	cmd.AddCommand(newTaskInspectCommand())
+	cmd.AddCommand(newTaskGetCommand())
 	cmd.AddCommand(newTaskLogsCommand())
 	cmd.AddCommand(newTaskPreemptCommand())
 	return cmd
@@ -33,11 +33,12 @@ func newTaskExecutionsCommand() *cobra.Command {
 	}
 }
 
-func newTaskInspectCommand() *cobra.Command {
+func newTaskGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <task...>",
-		Short: "Display detailed information about one or more tasks",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <task...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more tasks",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var tasks []api.Task
 			for _, id := range args {

--- a/cmd/beaker/workspace.go
+++ b/cmd/beaker/workspace.go
@@ -19,9 +19,9 @@ func newWorkspaceCommand() *cobra.Command {
 	cmd.AddCommand(newWorkspaceCreateCommand())
 	cmd.AddCommand(newWorkspaceDatasetsCommand())
 	cmd.AddCommand(newWorkspaceExperimentsCommand())
+	cmd.AddCommand(newWorkspaceGetCommand())
 	cmd.AddCommand(newWorkspaceGroupsCommand())
 	cmd.AddCommand(newWorkspaceImagesCommand())
-	cmd.AddCommand(newWorkspaceInspectCommand())
 	cmd.AddCommand(newWorkspaceListCommand())
 	cmd.AddCommand(newWorkspaceMoveCommand())
 	cmd.AddCommand(newWorkspacePermissionsCommand())
@@ -273,11 +273,12 @@ func newWorkspaceImagesCommand() *cobra.Command {
 	return cmd
 }
 
-func newWorkspaceInspectCommand() *cobra.Command {
+func newWorkspaceGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <workspace...>",
-		Short: "Display detailed information about one or more workspaces",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "get <workspace...>",
+		Aliases: []string{"inspect"},
+		Short:   "Display detailed information about one or more workspaces",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var workspaces []api.Workspace
 			for _, name := range args {
@@ -340,7 +341,7 @@ func newWorkspacePermissionsCommand() *cobra.Command {
 		Short: "Manage workspace permissions",
 	}
 	cmd.AddCommand(newWorkspacePermissionsGrantCommand())
-	cmd.AddCommand(newWorkspacePermissionsInspectCommand())
+	cmd.AddCommand(newWorkspacePermissionsGetCommand())
 	cmd.AddCommand(newWorkspacePermissionsRevokeCommand())
 	cmd.AddCommand(newWorkspacePermissionsSetVisibilityCommand())
 	return cmd
@@ -389,11 +390,12 @@ func newWorkspacePermissionsGrantCommand() *cobra.Command {
 	}
 }
 
-func newWorkspacePermissionsInspectCommand() *cobra.Command {
+func newWorkspacePermissionsGetCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "inspect <workspace>",
-		Short: "Inspect workspace permissions",
-		Args:  cobra.ExactArgs(1),
+		Use:     "get <workspace>",
+		Aliases: []string{"inspect"},
+		Short:   "Get workspace permissions",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			workspace, err := beaker.Workspace(ctx, args[0])
 			if err != nil {


### PR DESCRIPTION
Also adds an alias so `beaker <object> inspect` still works.