### PR TITLE
Add executor installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,45 @@ Beaker can also be installed from source using standard [Go](https://golang.org/
 ```bash
 go get -u github.com/allenai/beaker/...
 ```
+
+## Executor
+
+The Beaker executor runs Beaker jobs.
+If you want to run Beaker jobs on your own machines, you can install the Beaker executor.
+
+### Prerequisites
+
+The Beaker executor is only supported on Linux.
+It requires [Docker](https://docs.docker.com/engine/install/)
+and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+if using GPUs.
+
+### Installation
+
+Each executor belongs to a cluster.
+A cluster is a grouping of machines used for scheduling tasks.
+If a task is scheduled to a cluster, it may run on any of the machines in that cluster.
+
+You may choose an existing cluster from the existing [on-premise clusters](https://beaker.org/clusters) or create a new one:
+
+```
+beaker cluster create <name>
+```
+
+Next, install the executor:
+
+```
+beaker executor install <cluster>
+```
+
+When creating new experiments, specify the `cluster` property in each task
+and they will run on your machine.
+
+```yaml
+tasks:
+- context:
+    cluster: <cluster>
+```
+
 ## Notices
 [Beaker dependencies and licenses](https://app.fossa.io/attribution/a462337b-67c8-418e-8a05-9b6f67de4626)

--- a/cmd/beaker/executor_darwin.go
+++ b/cmd/beaker/executor_darwin.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newExecutorCommand() *cobra.Command {
+	// The executor is not supported on Mac.
+	return &cobra.Command{}
+}

--- a/cmd/beaker/executor_darwin.go
+++ b/cmd/beaker/executor_darwin.go
@@ -1,8 +1,17 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 func newExecutorCommand() *cobra.Command {
-	// The executor is not supported on Mac.
-	return &cobra.Command{}
+	return &cobra.Command{
+		Use:   "executor <command>",
+		Short: "Manage the executor",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("executor is not supported on Mac")
+		},
+	}
 }

--- a/cmd/beaker/executor_linux.go
+++ b/cmd/beaker/executor_linux.go
@@ -79,8 +79,10 @@ func newExecutorCommand() *cobra.Command {
 func newExecutorInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install <cluster>",
-		Short: "Install the Beaker executor",
-		Args:  cobra.ExactArgs(1),
+		Short: "Install and start the Beaker executor. May require sudo.",
+		Long: `Install the Beaker executor, start it, and configure it to run on boot.
+Requires access to /etc, /var, and /usr/bin. Also requires access to systemd.`,
+		Args: cobra.ExactArgs(1),
 	}
 
 	var configDir string

--- a/cmd/beaker/executor_linux.go
+++ b/cmd/beaker/executor_linux.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// The version URL must respond to a GET request with the latest version of the executor.
+	versionURL = "https://storage.googleapis.com/ai2-beaker-public/bin/latest"
+
+	// Replace %s with the version from the URL above.
+	executorURL = "https://storage.googleapis.com/ai2-beaker-public/bin/%s/executor"
+
+	// Path to the executor binary.
+	executorPath = "/usr/bin/beaker-executor"
+
+	// Name of the executor's systemd service.
+	executorService = "beaker-executor"
+
+	// Default location for storing Beaker configuration.
+	defaultConfigDir = "/etc/beaker"
+
+	// Default location for storing datasets.
+	defaultStorageDir = "/var/beaker"
+)
+
+var configTemplate = template.Must(template.New("config").Parse(`
+storagePath: {{.StoragePath}}
+beaker:
+  tokenPath: {{.TokenPath}}
+  cluster: {{.Cluster}}`))
+
+type configOpts struct {
+	StoragePath string
+	TokenPath   string
+	Cluster     string
+}
+
+var systemdTemplate = template.Must(template.New("systemd").Parse(`
+[Unit]
+Description=Beaker executor
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+ExecStart={{.BinaryPath}}
+Environment=CONFIG_PATH={{.ConfigPath}}
+
+[Install]
+WantedBy=multi-user.target`))
+
+type systemdOpts struct {
+	BinaryPath string
+	ConfigPath string
+}
+
+func newExecutorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "executor <command>",
+		Short: "Manage the executor",
+	}
+	cmd.AddCommand(newExecutorInstallCommand())
+	return cmd
+}
+
+func newExecutorInstallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install <cluster>",
+		Short: "Install the Beaker executor",
+		Args:  cobra.ExactArgs(1),
+	}
+
+	var configDir string
+	var storageDir string
+	cmd.Flags().StringVar(
+		&configDir,
+		"config-dir",
+		defaultConfigDir,
+		"Writeable directory for Beaker configuration")
+	cmd.Flags().StringVar(
+		&storageDir,
+		"storage-dir",
+		defaultStorageDir,
+		"Writeable directory for storing Beaker datasets")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := os.MkdirAll(configDir, os.ModePerm); err != nil {
+			return err
+		}
+
+		tokenPath := path.Join(configDir, "token")
+		if err := ioutil.WriteFile(
+			path.Join(configDir, "token"),
+			[]byte(beakerConfig.UserToken),
+			0600,
+		); err != nil {
+			return err
+		}
+
+		configPath := path.Join(configDir, "config.yml")
+		configFile, err := os.Create(configPath)
+		if err != nil {
+			return err
+		}
+		defer configFile.Close()
+		if err := configTemplate.Execute(configFile, configOpts{
+			StoragePath: storageDir,
+			TokenPath:   tokenPath,
+			Cluster:     args[0],
+		}); err != nil {
+			return err
+		}
+
+		systemdPath := fmt.Sprintf("/etc/systemd/system/%s.service", executorService)
+		systemdFile, err := os.Create(systemdPath)
+		if err != nil {
+			return err
+		}
+		defer systemdFile.Close()
+		if err := systemdTemplate.Execute(systemdFile, systemdOpts{
+			BinaryPath: executorPath,
+			ConfigPath: configPath,
+		}); err != nil {
+			return err
+		}
+
+		if err := downloadExecutor(); err != nil {
+			return err
+		}
+
+		return startExecutor()
+	}
+	return cmd
+}
+
+func downloadExecutor() error {
+	version, err := getLatestVersion()
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Get(fmt.Sprintf(executorURL, version))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(executorPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(executorPath, 0700)
+}
+
+func getLatestVersion() (string, error) {
+	resp, err := http.Get(versionURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	version, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(version)), nil
+}
+
+func startExecutor() error {
+	if err := exec.CommandContext(ctx, "systemctl", "daemon-reload").Run(); err != nil {
+		return err
+	}
+
+	if err := exec.CommandContext(ctx, "systemctl", "enable", executorService).Run(); err != nil {
+		return err
+	}
+
+	return exec.CommandContext(ctx, "systemctl", "start", executorService).Run()
+}

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -84,6 +84,7 @@ func main() {
 	root.AddCommand(newConfigCommand())
 	root.AddCommand(newDatasetCommand())
 	root.AddCommand(newExecutionCommand())
+	root.AddCommand(newExecutorCommand())
 	root.AddCommand(newExperimentCommand())
 	root.AddCommand(newGroupCommand())
 	root.AddCommand(newImageCommand())


### PR DESCRIPTION
```
beaker executor install -h
```

```
Install the Beaker executor, start it, and configure it to run on boot.
Requires access to /etc, /var, and /usr/bin. Also requires access to systemd.

Usage:
  beaker executor install <cluster> [flags]

Flags:
      --config-dir string    Writeable directory for Beaker configuration (default "/etc/beaker")
  -h, --help                 help for install
      --storage-dir string   Writeable directory for storing Beaker datasets (default "/var/beaker")

Global Flags:
      --format string   Output format
  -q, --quiet           Quiet mode
```