### PR TITLE
Don't prompt for login unless necessary

### DIFF
--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -62,11 +62,6 @@ func main() {
 			if beakerConfig, err = config.New(); err != nil {
 				return err
 			}
-			if beakerConfig.UserToken == "" {
-				if err := login(); err != nil {
-					return err
-				}
-			}
 
 			beaker, err = client.NewClient(
 				beakerConfig.BeakerAddress,
@@ -96,10 +91,13 @@ func main() {
 	root.AddCommand(newWorkspaceCommand())
 
 	err := root.Execute()
-	if err != nil && err.Error() == "invalid authentication token" {
-		err = login()
-		if err == nil {
-			err = root.Execute()
+	if err != nil {
+		switch err.Error() {
+		case "invalid authentication token", "user authentication required":
+			err = login()
+			if err == nil {
+				err = root.Execute()
+			}
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes a bug where commands that don't require login, like `beaker config set`, would still prompt for login. This prevents programmatically setting the user token using `beaker config set user_token` in the image builder. 