### PR TITLE
Use docker.NewClientWithOpts

### DIFF
--- a/cmd/beaker/image.go
+++ b/cmd/beaker/image.go
@@ -75,7 +75,7 @@ func newImageCreateCommand() *cobra.Command {
 			return err
 		}
 
-		docker, err := docker.NewEnvClient()
+		docker, err := docker.NewClientWithOpts(docker.FromEnv)
 		if err != nil {
 			return fmt.Errorf("failed to create Docker client: %w", err)
 		}
@@ -222,7 +222,7 @@ func newImagePullCommand() *cobra.Command {
 				tag = args[1]
 			}
 
-			docker, err := docker.NewEnvClient()
+			docker, err := docker.NewClientWithOpts(docker.FromEnv)
 			if err != nil {
 				return errors.Wrap(err, "failed to create Docker client")
 			}


### PR DESCRIPTION
`NewEnvClient` is deprecated.  The `WithOpts` form replaces it.