### PR TITLE
Make session list command more useful for reporting

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -192,31 +192,34 @@ func newSessionListCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	var all bool
 	var cluster string
 	var node string
 	var finalized bool
+	cmd.Flags().BoolVar(&all, "all", false, "List all sessions.")
 	cmd.Flags().StringVar(&cluster, "cluster", "", "Cluster to list sessions.")
 	cmd.Flags().StringVar(&node, "node", "", "Node to list sessions. Defaults to current node.")
 	cmd.Flags().BoolVar(&finalized, "finalized", false, "Show only finalized sessions")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		opts := client.ListSessionOpts{
-			Finalized: &finalized,
-		}
+		var opts client.ListSessionOpts
+		if !all {
+			opts.Finalized = &finalized
 
-		if cluster != "" {
-			opts.Cluster = &cluster
-		}
-
-		if !cmd.Flag("node").Changed && cluster == "" {
-			var err error
-			node, err = getCurrentNode()
-			if err != nil {
-				return fmt.Errorf("failed to detect node; use --node flag: %w", err)
+			if cluster != "" {
+				opts.Cluster = &cluster
 			}
-		}
-		if node != "" {
-			opts.Node = &node
+
+			if !cmd.Flag("node").Changed && cluster == "" {
+				var err error
+				node, err = getCurrentNode()
+				if err != nil {
+					return fmt.Errorf("failed to detect node; use --node flag: %w", err)
+				}
+			}
+			if node != "" {
+				opts.Node = &node
+			}
 		}
 
 		sessions, err := beaker.ListSessions(ctx, &opts)


### PR DESCRIPTION
```
$ beaker session list --all | head -n 10
ID                          NAME  AUTHOR  STATUS     SCHEDULED        DURATION   GPUS
01F0ESAHJJ2T9P4FN3F0G4WEE1  N/A   lanea   failed     Mar 10 19:20:28  00:00:06   0
01F0ESFMAE5KS4K90WQVCVM5MW  N/A   lanea   failed     Mar 10 19:23:13  00:00:02   0
01F0ESJK23TK596BGF729BFGK2  N/A   lanea   failed     Mar 10 19:24:52  457:27:17  0
01F0ETCJ6B3AB7ZWMAZQ0089QE  N/A   lanea   succeeded  Mar 10 19:45:51  00:01:23   0
01F0ETEWHW837C00EKME37FCWM  N/A   lanea   succeeded  Mar 10 19:47:16  00:01:52   0
01F0ETJ6479N74PNHDHGDV8PP1  N/A   lanea   succeeded  Mar 10 19:49:11  00:01:51   0
01F0EV5Q8MBJE0XPXE0BH3TYYR  N/A   lanea   succeeded  Mar 10 19:52:48  00:01:03   0
01F0EVAGHAQQQ2Z626DMQAC4YA  N/A   lanea   failed     Mar 10 19:55:25  00:00:29   0
01F0EVK8CW2RXQ36D4FRAR5M2S  N/A   lanea   failed     N/A              00:00:00   N/A
```