### PR TITLE
Handle cancellation while starting a session

### DIFF
--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -101,7 +101,10 @@ func main() {
 		}
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s %+v\n", color.RedString("Error:"), err)
+		// Don't print "context canceled" error on Ctrl-C.
+		if !errors.Is(err, context.Canceled) {
+			fmt.Fprintf(os.Stderr, "%s %+v\n", color.RedString("Error:"), err)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -280,7 +280,7 @@ func startSession(
 
 	if !quiet && session.Limits != nil {
 		fmt.Printf(
-			"Session assigned %d GPU, %v CPU, %.1fGiB memory\n",
+			"Reserved %d GPU, %v CPU, %.1fGiB memory\n",
 			len(session.Limits.GPUs),
 			session.Limits.CPUCount,
 			// TODO Use friendly formatting from bytefmt when available.


### PR DESCRIPTION
If the user hits Ctrl-C after before a session is started, we will have an orphaned session. The executor will clean it up eventually, but only after the session is scheduled and not started for 5 minutes. This change automatically cancels the session instead. 