### PR TITLE
Make session feedback more immediate

### DIFF
--- a/cmd/beaker/experiment.go
+++ b/cmd/beaker/experiment.go
@@ -9,11 +9,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/allenai/bytefmt"
 	"github.com/beaker/client/api"
 	"github.com/beaker/client/client"
 	"github.com/fatih/color"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -356,24 +354,4 @@ func openPath(p string) (io.Reader, error) {
 		return os.Stdin, nil
 	}
 	return os.Open(p)
-}
-
-// canonicalizeSpecV1 fills out JSON fields used by the API from YAML fields parsed from disk.
-func canonicalizeSpecV1(spec *api.ExperimentSpecV1) error {
-	// TODO: This should be unnecessary when the service accepts YAML directly.
-	for i := range spec.Tasks {
-		reqs := &spec.Tasks[i].Spec.Requirements
-		if reqs.CPU < 0 {
-			return errors.Errorf("couldn't parse cpu argument '%.2f' because it was negative", reqs.CPU)
-		}
-		reqs.MilliCPU = int(reqs.CPU * 1000)
-		if reqs.MemoryHuman != "" {
-			size, err := bytefmt.Parse(reqs.MemoryHuman)
-			if err != nil {
-				return errors.Wrapf(err, "invalid memory value %q", reqs.MemoryHuman)
-			}
-			reqs.Memory = int64(size.Int64())
-		}
-	}
-	return nil
 }

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -339,7 +339,7 @@ func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 	}
 
 	// Subtract each running session from its node's capacity.
-	// TODO: This is duplicative of executions above. We should consolidate.
+	// TODO allenai/beaker-service#1426: This is duplicative of executions above.
 	for _, sess := range sessions {
 		node, ok := nodesByID[session.Node]
 		if !ok || node.Limits == nil {

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
+	"strconv"
 	"strings"
 	"time"
 
@@ -80,8 +82,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if node == "" {
 			var err error
-			node, err = getCurrentNode()
-			if err != nil {
+			if node, err = getCurrentNode(); err != nil {
 				return fmt.Errorf("failed to detect node; use --node flag: %w", err)
 			}
 		}
@@ -97,13 +98,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 			return err
 		}
 
-		// Pass nil instead of empty slice when there are no arguments.
-		var command []string
-		if len(args) > 0 {
-			command = args
-		}
-
-		if err := startSession(session.ID, image, command); err != nil {
+		cancel := func() {
 			// If we fail to start the session, cancel it so that the executor
 			// can immediately reclaim the resources allocated to it.
 			//
@@ -111,11 +106,74 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 			_, _ = beaker.Session(session.ID).Patch(context.Background(), api.SessionPatch{
 				State: &api.ExecStatusUpdate{Canceled: true},
 			})
+		}
+
+		if !quiet {
+			fmt.Print("Scheduling session")
+			if req := resourceRequestString(session.Requests); req != "" {
+				fmt.Print(" with at least", req)
+			}
+			fmt.Println("... (Press Ctrl+C to cancel)")
+		}
+
+		if session, err = awaitSessionSchedule(*session); err != nil {
+			cancel()
+			return err
+		}
+
+		if lim := resourceLimitString(session.Limits); !quiet && lim != "" {
+			fmt.Println("Reserved", lim)
+		}
+
+		// Pass nil instead of empty slice when there are no arguments.
+		var command []string
+		if len(args) > 0 {
+			command = args
+		}
+
+		if err := startSession(*session, image, command); err != nil {
+			cancel()
 			return err
 		}
 		return nil
 	}
 	return cmd
+}
+
+func resourceRequestString(req *api.TaskResources) string {
+	if req == nil {
+		return ""
+	}
+	return resourceString(req.GPUCount, req.CPUCount, req.Memory)
+}
+
+func resourceLimitString(limits *api.SessionResources) string {
+	if limits == nil {
+		return ""
+	}
+	return resourceString(len(limits.GPUs), limits.CPUCount, limits.Memory)
+}
+
+func resourceString(gpuCount int, cpuCount float64, memory *bytefmt.Size) string {
+	var requests []string
+	if gpuCount == 1 {
+		requests = append(requests, "1 GPU")
+	} else if gpuCount != 0 {
+		requests = append(requests, fmt.Sprintf("%d GPUs", gpuCount))
+	}
+
+	if cpuCount == 1 {
+		requests = append(requests, "1 CPU")
+	} else if cpuCount > 0 {
+		// Format with FormatFloat instead of Printf so we can use -1 precision.
+		requests = append(requests, strconv.FormatFloat(cpuCount, 'f', -1, 64)+" CPUs")
+	}
+
+	if memory != nil {
+		requests = append(requests, memory.String()+" memory")
+	}
+
+	return strings.Join(requests, ", ")
 }
 
 func newSessionExecCommand() *cobra.Command {
@@ -190,8 +248,7 @@ func newSessionListCommand() *cobra.Command {
 
 			if !cmd.Flag("node").Changed && cluster == "" {
 				var err error
-				node, err = getCurrentNode()
-				if err != nil {
+				if node, err = getCurrentNode(); err != nil {
 					return fmt.Errorf("failed to detect node; use --node flag: %w", err)
 				}
 			}
@@ -233,55 +290,121 @@ func newSessionUpdateCommand() *cobra.Command {
 	return cmd
 }
 
-func awaitSessionSchedule(session string) (*api.Session, error) {
-	if !quiet {
-		fmt.Printf("Waiting for session to be scheduled")
+func awaitSessionSchedule(session api.Session) (*api.Session, error) {
+	s := beaker.Session(session.ID)
+	cl := beaker.Cluster(session.Cluster)
+
+	nodes, err := cl.ListClusterNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list cluster nodes: %w", err)
 	}
-	delay := time.NewTimer(0) // No delay on first attempt.
+
+	nodesByID := make(map[string]*api.Node, len(nodes))
+	for _, node := range nodes {
+		node := node
+		nodesByID[node.ID] = &node
+	}
+
+	execs, err := cl.ListExecutions(ctx, &client.ExecutionFilters{
+		Scheduled: api.BoolPtr(true),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get cluster job queue: %w", err)
+	}
+
+	// Calculate the available capacity of each node in the cluster.
+	for _, exec := range execs {
+		node, ok := nodesByID[exec.Node]
+		if !ok || node.Limits == nil {
+			continue
+		}
+
+		node.Limits.CPUCount -= exec.Limits.CPUCount
+		node.Limits.GPUCount -= exec.Limits.GPUCount
+		if node.Limits.Memory != nil && exec.Limits.Memory != nil {
+			node.Limits.Memory.Sub(*exec.Limits.Memory)
+		}
+	}
+
+	var capacityErr string
+	if node, ok := nodesByID[session.Node]; !ok {
+		capacityErr = "the node has been deleted"
+	} else if err := checkNodeCapacity(node, session.Requests); err != nil {
+		capacityErr = err.Error()
+	}
+
+	if capacityErr != "" {
+		// Find all nodes which could schedule this session.
+		var hosts []string
+		for _, node := range nodesByID {
+			// Don't bother checking this node again.
+			if node.ID == session.Node {
+				continue
+			}
+
+			// Skip nodes where the session won't fit.
+			if checkNodeCapacity(node, session.Requests) != nil {
+				continue
+			}
+
+			hosts = append(hosts, node.Hostname)
+		}
+
+		fmt.Printf("This session is unlikely to to start because %s.\n", capacityErr)
+		fmt.Println("You may continue waiting or launch a new session on one of the following hosts:")
+		fmt.Println("    " + strings.Join(hosts, "\n    "))
+	}
+
+	delay := time.NewTimer(0) // When to poll session status.
 	for attempt := 0; ; attempt++ {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 
 		case <-delay.C:
-			info, err := beaker.Session(session).Get(ctx)
+			session, err := s.Get(ctx)
 			if err != nil {
 				return nil, err
 			}
 
-			if info.State.Scheduled != nil {
-				if !quiet {
-					fmt.Println()
-				}
-				return info, nil
+			if session.State.Scheduled != nil {
+				return session, nil
 			}
-			if !quiet {
-				fmt.Print(".")
-			}
-			delay.Reset(time.Second)
+
+			delay.Reset(3 * time.Second)
 		}
 	}
 }
 
-func startSession(
-	sessionID string,
-	image string,
-	command []string,
-) error {
-	session, err := awaitSessionSchedule(sessionID)
-	if err != nil {
-		return err
-	}
+func checkNodeCapacity(node *api.Node, request *api.TaskResources) error {
+	switch {
+	case node.Limits == nil:
+		// Node has unbounded capacity.
+		return nil
 
-	if !quiet && session.Limits != nil {
-		fmt.Printf(
-			"Reserved %d GPU, %v CPU, %.1fGiB memory\n",
-			len(session.Limits.GPUs),
-			session.Limits.CPUCount,
-			// TODO Use friendly formatting from bytefmt when available.
-			float64(session.Limits.Memory.Int64())/float64(bytefmt.GiB))
-	}
+	case node.Cordoned != nil:
+		return errors.New("the node is cordoned")
 
+	case request == nil:
+		// No request means it'll fit anywhere.
+		return nil
+
+	case node.Limits.CPUCount < request.CPUCount:
+		return errors.New("there are not enough available CPUs")
+
+	case node.Limits.GPUCount < request.GPUCount:
+		return errors.New("there are not enough available GPUs")
+
+	case node.Limits.Memory != nil && request.Memory != nil &&
+		node.Limits.Memory.Cmp(*request.Memory) < 0:
+		return errors.New("there is not enough available memory")
+
+	default:
+		return nil // All checks passed.
+	}
+}
+
+func startSession(session api.Session, image string, command []string) error {
 	labels := map[string]string{
 		sessionContainerLabel: session.ID,
 		sessionGPULabel:       strings.Join(session.Limits.GPUs, ","),

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -293,7 +293,7 @@ func newSessionUpdateCommand() *cobra.Command {
 
 func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 	s := beaker.Session(session.ID)
-	cl := beaker.Cluster("ai2/" + session.Cluster)
+	cl := beaker.Cluster(session.Cluster)
 
 	nodes, err := cl.ListClusterNodes(ctx)
 	if err != nil {

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -385,7 +385,7 @@ func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 func checkNodeCapacity(node *api.Node, request *api.TaskResources) error {
 	switch {
 	case node.Limits == nil:
-		// Node has unbounded capacity.
+		// Node has unknown capacity. Treat it as unbounded.
 		return nil
 
 	case node.Cordoned != nil:


### PR DESCRIPTION
During session creation, instead of waiting forever with an ever-expanding ellipsis, Beaker will now detect whether the session is likely to schedule.  If not, it prints a message indicating why the session is waiting and redirects the user to other nodes.