### PR TITLE
Use the resolved image.

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -219,7 +219,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 		container, err := rt.CreateContainer(ctx, &runtime.ContainerOpts{
 			Name: strings.ToLower("session-" + session.ID),
 			Image: &runtime.DockerImage{
-				Tag: image,
+				Tag: rtImage.Tag,
 			},
 			Command:     command,
 			Labels:      labels,


### PR DESCRIPTION
Prior to this change we were using the original image tag,
as passed by the client. This will look something like:

```
beaker://sams:latest
```

The "scheme" is something that's specific to our client which
won't be understood by Docker, so we need to use the resolved
image instead.