### PR TITLE
Create separate alt-home dirs for each user.

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -122,9 +122,13 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 				return fmt.Errorf("couldn't load Beaker config: %w", err)
 			}
 
+			if u.Username == "" {
+				return errors.New("the current user has no name")
+			}
+
 			// The "home" directory should already exist with r/w permissions for all users.
 			// The child directory is restricted to the user's account in case they store secrets.
-			home.HostPath = filepath.Join(config.StoragePath, "home", u.Name)
+			home.HostPath = filepath.Join(config.StoragePath, "home", u.Username)
 			if err := os.MkdirAll(home.HostPath, 0700); err != nil {
 				return fmt.Errorf("couldn't create alternate home directory: %w", err)
 			}


### PR DESCRIPTION
It turns out the `Name` property of `User` can be blank.
From https://golang.org/pkg/os/user/#User:

```
    // Username is the login name.
    Username string
    // Name is the user's real or display name.
    // It might be blank.
    // On POSIX systems, this is the first (or only) entry in the GECOS field
    // list.
    // On Windows, this is the user's display name.
    // On Plan 9, this is the contents of /dev/user.
    Name string
```

It appears this is often the case, as it's what caused the bug
Oyvind and MattG ran into. They both ended up getting a home
path of `/var/beaker/home`, because `u.Name` was `""`.

This fixes that by using `Username`. I built a binary and
tested this out on `beaker-server1` (where I can't technically launch
a session, but I used good ole' `PrintLn()` debugging to make sure
the path was correct after the change.

I also added a guard that'll error out if `Username` is `""`,
so that the user doesn't end up writing things into `/var/beaker/home`.

We'll need to figure out what to do with the files that are
there. I imagine we might need to create `/var/beaker/home/oyvindt` and
`/var/beaker/home/mattg` manually and copy the files in `/var/beaker/home`
to both.

This fixes: https://github.com/allenai/beaker-service/issues/1446.