### PR TITLE
Enable configurable home directory

### DIFF
--- a/cmd/beaker/executor.go
+++ b/cmd/beaker/executor.go
@@ -23,7 +23,13 @@ var (
 )
 
 type executorConfig struct {
+	// (optional) Path to the Beaker agent's local storage.
 	StoragePath string `yaml:"storagePath"`
+
+	// (optional) Parent directory of session home directories. This can be set
+	// to an NFS to enable roaming profiles. If unset, sessions mount the
+	// invoking user's home directory.
+	SessionHome string `yaml:"sessionHome"`
 }
 
 // Get the config of the executor running on this machine.
@@ -38,6 +44,12 @@ func getExecutorConfig() (*executorConfig, error) {
 	if err := yaml.NewDecoder(expanded).Decode(&config); err != nil {
 		return nil, err
 	}
+
+	if config.SessionHome == "" {
+		os.UserHomeDir()
+		config.SessionHome = path.Join(config.StoragePath, "home")
+	}
+
 	return &config, nil
 }
 

--- a/cmd/beaker/executor.go
+++ b/cmd/beaker/executor.go
@@ -27,7 +27,7 @@ type executorConfig struct {
 	StoragePath string `yaml:"storagePath"`
 
 	// (optional) Parent directory of session home directories. This can be set
-	// to an NFS to enable roaming profiles. If unset, sessions mount the
+	// to an NFS mount to enable roaming profiles. If unset, sessions mount the
 	// invoking user's home directory.
 	SessionHome string `yaml:"sessionHome"`
 }

--- a/cmd/beaker/executor.go
+++ b/cmd/beaker/executor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -46,8 +47,11 @@ func getExecutorConfig() (*executorConfig, error) {
 	}
 
 	if config.SessionHome == "" {
-		os.UserHomeDir()
-		config.SessionHome = path.Join(config.StoragePath, "home")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("couldn't find home directory: %w", err)
+		}
+		config.SessionHome = home
 	}
 
 	return &config, nil

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -77,7 +77,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 		"image",
 		"beaker://ai2/cuda11.2-ubuntu20.04",
 		"Base image to run, may be a Beaker or Docker image")
-	cmd.Flags().BoolVar(&localHome, "local-home", false, "Ignore Beaker configuration and always mount the invoking user's home directory")
+	cmd.Flags().BoolVar(&localHome, "local-home", false, "Mount the invoking user's home directory, ignoring Beaker configuration")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Assign a name to the session")
 	cmd.Flags().StringVar(&node, "node", "", "Node that the session will run on. Defaults to current node.")
 	cmd.Flags().StringVar(&pull, "pull", string(runtime.PullIfMissing), fmt.Sprintf(
@@ -124,7 +124,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 				// should consider using the stable Beaker user ID instead.
 				home.HostPath = filepath.Join(config.SessionHome, u.Username)
 				if err := os.MkdirAll(home.HostPath, 0700); err != nil {
-					return fmt.Errorf("couldn't create alternate home directory: %w", err)
+					return fmt.Errorf("couldn't create home directory: %w", err)
 				}
 			}
 		}

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -67,17 +67,17 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 		Args: cobra.ArbitraryArgs,
 	}
 
-	var altHome bool
+	var localHome bool
 	var image string
 	var name string
 	var node string
 	var pull string
-	cmd.Flags().BoolVar(&altHome, "alt-home", false, "Mount alternate home directory managed by Beaker (experimental)")
 	cmd.Flags().StringVar(
 		&image,
 		"image",
 		"beaker://ai2/cuda11.2-ubuntu20.04",
 		"Base image to run, may be a Beaker or Docker image")
+	cmd.Flags().BoolVar(&localHome, "local-home", false, "Ignore Beaker configuration and always mount the invoking user's home directory")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Assign a name to the session")
 	cmd.Flags().StringVar(&node, "node", "", "Node that the session will run on. Defaults to current node.")
 	cmd.Flags().StringVar(&pull, "pull", string(runtime.PullIfMissing), fmt.Sprintf(
@@ -116,21 +116,16 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 
 		userGroup := u.Uid + ":" + u.Gid
 		home := runtime.Mount{HostPath: u.HomeDir, ContainerPath: u.HomeDir}
-		if altHome {
-			config, err := getExecutorConfig()
-			if err != nil {
-				return fmt.Errorf("couldn't load Beaker config: %w", err)
-			}
 
-			if u.Username == "" {
-				return errors.New("the current user has no name")
-			}
-
-			// The "home" directory should already exist with r/w permissions for all users.
-			// The child directory is restricted to the user's account in case they store secrets.
-			home.HostPath = filepath.Join(config.StoragePath, "home", u.Username)
-			if err := os.MkdirAll(home.HostPath, 0700); err != nil {
-				return fmt.Errorf("couldn't create alternate home directory: %w", err)
+		// Mount in a Beaker-managed home directory by default, if there's one configured.
+		if !localHome {
+			if config, err := getExecutorConfig(); err == nil {
+				// TODO: u.Username is highly dependent on host configuration. We
+				// should consider using the stable Beaker user ID instead.
+				home.HostPath = filepath.Join(config.SessionHome, u.Username)
+				if err := os.MkdirAll(home.HostPath, 0700); err != nil {
+					return fmt.Errorf("couldn't create alternate home directory: %w", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
Part 2 of 3 for NFS-based roaming profiles: coordinate with the installed executor when possible to determine the session home directory mount. 