### PR TITLE
Produce a more useful error when user hasn't authed

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -131,6 +132,14 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 
 		rtImage, err := resolveImage(beaker, image)
 		if err != nil {
+			var apiErr api.Error
+			if errors.As(err, &apiErr) &&
+				(apiErr.Code == http.StatusForbidden || apiErr.Code == http.StatusNotFound) &&
+				beakerConfig.UserToken == "" {
+				// Special case: produce a more useful error when the user hasn't authenticated.
+				return fmt.Errorf("access to %q may be restricted; please log in by following instructions at https://beaker.org/user", image)
+			}
+
 			return fmt.Errorf("invalid image: %w", err)
 		}
 


### PR DESCRIPTION
This replaces an often confusing error about an invalid image with a clearer error prompting the user to sign in.