### PR TITLE
Fix default session home

### DIFF
--- a/cmd/beaker/executor.go
+++ b/cmd/beaker/executor.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -44,14 +43,6 @@ func getExecutorConfig() (*executorConfig, error) {
 	var config executorConfig
 	if err := yaml.NewDecoder(expanded).Decode(&config); err != nil {
 		return nil, err
-	}
-
-	if config.SessionHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("couldn't find home directory: %w", err)
-		}
-		config.SessionHome = home
 	}
 
 	return &config, nil

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -126,14 +126,12 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 		home := runtime.Mount{HostPath: u.HomeDir, ContainerPath: u.HomeDir}
 
 		// Mount in a Beaker-managed home directory by default, if there's one configured.
-		if !localHome {
-			if config, err := getExecutorConfig(); err == nil {
-				// TODO: u.Username is highly dependent on host configuration. We
-				// should consider using the stable Beaker user ID instead.
-				home.HostPath = filepath.Join(config.SessionHome, u.Username)
-				if err := os.MkdirAll(home.HostPath, 0700); err != nil {
-					return fmt.Errorf("couldn't create home directory: %w", err)
-				}
+		if config, err := getExecutorConfig(); err == nil && config.SessionHome != "" && !localHome {
+			// TODO: u.Username is highly dependent on host configuration. We
+			// should consider using the stable Beaker user ID instead.
+			home.HostPath = filepath.Join(config.SessionHome, u.Username)
+			if err := os.MkdirAll(home.HostPath, 0700); err != nil {
+				return fmt.Errorf("couldn't create home directory: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Currently, if `sessionHome` is not configured, `~/<user>` is used e.g. `/home/lanea/lanea`. ​I think this is a bug that we didn't notice because we always configure `sessionHome`. This change makes `sessionHome` default to `~`.

Part of https://github.com/allenai/reviz/issues/263