### PR TITLE
Prompt for token if not logged in when creating a session

### DIFF
--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -92,8 +92,8 @@ func main() {
 
 	err := root.Execute()
 	if err != nil {
-		switch err.Error() {
-		case "invalid authentication token", "user authentication required":
+		if strings.HasSuffix(err.Error(), "invalid authentication token") ||
+			strings.HasSuffix(err.Error(), "user authentication required") {
 			err = login()
 			if err == nil {
 				err = root.Execute()

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -139,15 +138,7 @@ To pass flags, use "--" e.g. "create -- ls -l"`,
 
 		rtImage, err := resolveImage(beaker, image)
 		if err != nil {
-			var apiErr api.Error
-			if errors.As(err, &apiErr) &&
-				(apiErr.Code == http.StatusForbidden || apiErr.Code == http.StatusNotFound) &&
-				beakerConfig.UserToken == "" {
-				// Special case: produce a more useful error when the user hasn't authenticated.
-				return fmt.Errorf("access to %q may be restricted; please log in by following instructions at https://beaker.org/user", image)
-			}
-
-			return fmt.Errorf("invalid image: %w", err)
+			return err
 		}
 
 		session, err := beaker.CreateSession(ctx, api.SessionSpec{


### PR DESCRIPTION
We had a special case for this but it only handled a missing token, not an incorrect one. I made the general error handling for invalid tokens handle wrapped errors so this special case is no longer necessary. 

Fixes https://github.com/allenai/beaker/issues/304