### PR TITLE
Fix hang on verifying image

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -529,13 +529,15 @@ func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 			hosts = append(hosts, node.Hostname)
 		}
 
-		fmt.Printf("This session is unlikely to to start because %s.\n", capacityErr)
-		fmt.Println("You may continue waiting to hold your place in the queue.")
-		if len(hosts) == 0 {
-			fmt.Println("There are no other nodes on this cluster with sufficient capacity.")
-		} else {
-			fmt.Println("You could also try one of the following available nodes:")
-			fmt.Println("    " + strings.Join(hosts, "\n    "))
+		if !quiet {
+			fmt.Printf("This session is unlikely to to start because %s.\n", capacityErr)
+			fmt.Println("You may continue waiting to hold your place in the queue.")
+			if len(hosts) == 0 {
+				fmt.Println("There are no other nodes on this cluster with sufficient capacity.")
+			} else {
+				fmt.Println("You could also try one of the following available nodes:")
+				fmt.Println("    " + strings.Join(hosts, "\n    "))
+			}
 		}
 	}
 

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -538,9 +538,13 @@ func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 				fmt.Println("You could also try one of the following available nodes:")
 				fmt.Println("    " + strings.Join(hosts, "\n    "))
 			}
+			fmt.Println()
 		}
 	}
 
+	if !quiet {
+		fmt.Printf("Waiting for session to be scheduled")
+	}
 	delay := time.NewTimer(0) // When to poll session status.
 	for attempt := 0; ; attempt++ {
 		select {
@@ -554,9 +558,15 @@ func awaitSessionSchedule(session api.Session) (*api.Session, error) {
 			}
 
 			if session.State.Scheduled != nil {
+				if !quiet {
+					fmt.Println()
+				}
 				return session, nil
 			}
 
+			if !quiet {
+				fmt.Print(".")
+			}
 			delay.Reset(3 * time.Second)
 		}
 	}

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -583,6 +583,11 @@ func checkNodeCapacity(node *api.Node, request *api.TaskResources) error {
 		node.Limits.Memory.Cmp(*request.Memory) < 0:
 		return errors.New("there is not enough available memory")
 
+	case node.Limits.CPUCount == 0 &&
+		node.Limits.GPUCount == 0 &&
+		(node.Limits.Memory == nil || node.Limits.Memory.IsZero()):
+		return errors.New("the node has no space left")
+
 	default:
 		return nil // All checks passed.
 	}


### PR DESCRIPTION
Fixes https://github.com/allenai/beaker-service/issues/1504

In `checkNodeCapacity`, we were checking the session's request against the node's limits. If the session's request was empty, as it usually is, the capacity check would always pass, even if the node had no resources left.

Since the session's limits are not populated until the session is scheduled, we can't check against that. Instead, I added a check for zero node resources. If the node has no resources left, the session won't be able to schedule, no matter its request. We will print the following error instead of hanging:

```
This session is unlikely to to start because the node has no space left.
You may continue waiting to hold your place in the queue.
```

I also added back the `Waiting for session to be scheduled...` message. Not having this message made it look like the CLI was stuck verifying the image when it was actually waiting for the session to be scheduled. 