### PR TITLE
Fix #1565; Don't panic when cluster nodes dont have memory.

### DIFF
--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -69,7 +69,9 @@ func printClusters(clusters []api.Cluster) error {
 				gpuType = cluster.NodeShape.GPUType
 				gpuCount = cluster.NodeShape.GPUCount
 				cpuCount = cluster.NodeShape.CPUCount
-				memory = cluster.NodeShape.Memory.String()
+				if cluster.NodeShape.Memory != nil {
+					memory = cluster.NodeShape.Memory.String()
+				}
 			}
 			if err := printTableRow(
 				cluster.Name,


### PR DESCRIPTION
This was failing because `cluster.NodeShape.Memory` is `nil` in
some cases. After this change the CLI will print `N/A` instead
of segfaulting.

I tried to find a recent change that may have caused this but
couldn't. That said being defensive here doesn't seem like
a bad thing to do, so I don't feel the need to exhaustively
root cause this.