### PR TITLE
Fix inconsistent name/ID treatment

### DIFF
--- a/cmd/beaker/cluster.go
+++ b/cmd/beaker/cluster.go
@@ -95,7 +95,9 @@ func newClusterCreateCommand() *cobra.Command {
 			return err
 		}
 
-		fmt.Printf("Cluster %s created (ID %s)\n", color.BlueString(cluster.Name), color.BlueString(cluster.ID))
+		fmt.Printf("Cluster %s created. See details at %s/cl/%s\n",
+			color.BlueString(cluster.FullName), beaker.Address(), cluster.FullName)
+
 		if !cluster.Autoscale {
 			return nil
 		}

--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -97,7 +97,7 @@ func printDatasets(datasets []api.Dataset) error {
 			"ID",
 			"WORKSPACE",
 			"AUTHOR",
-			"COMMITTED",
+			"CREATED",
 			"SOURCE EXECUTION",
 		); err != nil {
 			return err
@@ -111,7 +111,7 @@ func printDatasets(datasets []api.Dataset) error {
 				name,
 				dataset.Workspace.FullName,
 				dataset.Author.Name,
-				dataset.Committed,
+				dataset.Created,
 				dataset.SourceExecution,
 			); err != nil {
 				return err

--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -74,7 +74,7 @@ func printClusters(clusters []api.Cluster) error {
 				}
 			}
 			if err := printTableRow(
-				cluster.Name,
+				cluster.FullName,
 				gpuType,
 				gpuCount,
 				cpuCount,
@@ -104,12 +104,12 @@ func printDatasets(datasets []api.Dataset) error {
 		}
 		for _, dataset := range datasets {
 			name := dataset.ID
-			if dataset.Name != "" {
-				name = dataset.Name
+			if dataset.FullName != "" {
+				name = dataset.FullName
 			}
 			if err := printTableRow(
 				name,
-				dataset.Workspace.Name,
+				dataset.Workspace.FullName,
 				dataset.Author.Name,
 				dataset.Committed,
 				dataset.SourceExecution,
@@ -137,8 +137,8 @@ func printExperiments(experiments []api.Experiment) error {
 		}
 		for _, experiment := range experiments {
 			name := experiment.ID
-			if experiment.Name != "" {
-				name = experiment.Name
+			if experiment.FullName != "" {
+				name = experiment.FullName
 			}
 			var executions []api.Execution
 			for _, execution := range experiment.Executions {
@@ -146,7 +146,7 @@ func printExperiments(experiments []api.Experiment) error {
 			}
 			if err := printTableRow(
 				name,
-				experiment.Workspace.Name,
+				experiment.Workspace.FullName,
 				experiment.Author.Name,
 				experiment.Created,
 				executionsStatus(executions),
@@ -173,12 +173,12 @@ func printGroups(groups []api.Group) error {
 		}
 		for _, group := range groups {
 			name := group.ID
-			if group.Name != "" {
-				name = group.Name
+			if group.FullName != "" {
+				name = group.FullName
 			}
 			if err := printTableRow(
 				name,
-				group.Workspace.Name,
+				group.Workspace.FullName,
 				group.Author.Name,
 				group.Created,
 			); err != nil {
@@ -204,12 +204,12 @@ func printImages(images []api.Image) error {
 		}
 		for _, image := range images {
 			name := image.ID
-			if image.Name != "" {
-				name = image.Name
+			if image.FullName != "" {
+				name = image.FullName
 			}
 			if err := printTableRow(
 				name,
-				image.Workspace.Name,
+				image.Workspace.FullName,
 				image.Author.Name,
 				image.Created,
 			); err != nil {
@@ -459,7 +459,7 @@ func printWorkspaces(workspaces []api.Workspace) error {
 		}
 		for _, workspace := range workspaces {
 			if err := printTableRow(
-				workspace.Name,
+				workspace.FullName,
 				workspace.Author.Name,
 				workspace.Size.Datasets,
 				workspace.Size.Experiments,

--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -19,7 +19,7 @@ func printTableRow(cells ...interface{}) error {
 		var formatted string
 		if t, ok := cell.(time.Time); ok {
 			if !t.IsZero() {
-				formatted = t.Format(time.Stamp)
+				formatted = t.Local().Format("2006-01-02 15:04:05")
 			}
 		} else if d, ok := cell.(time.Duration); ok {
 			// Format duration as HH:MM:SS.

--- a/cmd/beaker/workspace.go
+++ b/cmd/beaker/workspace.go
@@ -67,15 +67,20 @@ func newWorkspaceCreateCommand() *cobra.Command {
 			Organization: org,
 		}
 
-		workspace, err := beaker.CreateWorkspace(ctx, spec)
+		wsRef, err := beaker.CreateWorkspace(ctx, spec)
+		if err != nil {
+			return err
+		}
+		workspace, err := wsRef.Get(ctx)
 		if err != nil {
 			return err
 		}
 
 		if quiet {
-			fmt.Println(workspace.Ref())
+			fmt.Println(workspace.ID)
 		} else {
-			fmt.Printf("Workspace %s created (ID %s)\n", color.BlueString(spec.Name), color.BlueString(workspace.Ref()))
+			fmt.Printf("Workspace %s created. See details at %s/ws/%s\n",
+				color.BlueString(workspace.FullName), beaker.Address(), workspace.FullName)
 		}
 		return nil
 	}


### PR DESCRIPTION
This change addresses some usability issues I noticed while updating docs.

```diff
▶ beaker workspace create foo
- Workspace foo created (ID 01FBK09NXR60M06BGC3JVKBNRY)
+ Workspace ckarenz/foo created. See details at https://beaker.org/ws/ckarenz/foo
```

```diff
▶ beaker cluster create ai2/foo
- Cluster ai2/foo created (ID us_wvnghctl47k0/01FBK08HSBZ933WVJB3YDSMHTT)
+ Cluster ai2/foo created. See details at https://beaker.org/cl/ai2/foo
```

```diff
▶ beaker image get examples/wordcount
- ID         WORKSPACE  AUTHOR    CREATED
- wordcount  examples   examples  Aug 22 22:47:10
+ ID                  WORKSPACE          AUTHOR    CREATED
+ examples/wordcount  examples/examples  examples  2018-08-22 15:47:10
```

```diff
▶ beaker dataset get examples/moby
- ID    WORKSPACE  AUTHOR    COMMITTED        SOURCE EXECUTION
- moby  examples   examples  Aug 22 22:35:56  N/A
+ ID             WORKSPACE          AUTHOR    CREATED              SOURCE EXECUTION
+ examples/moby  examples/examples  examples  2018-08-22 15:35:55  N/A
```