### PR TITLE
Add support for saving session images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.4.19 // indirect
 	github.com/allenai/bytefmt v0.1.2
-	github.com/beaker/client v0.0.0-20210823213835-37bd0af3bc90
+	github.com/beaker/client v0.0.0-20210913212946-64994f6928fc
 	github.com/beaker/fileheap v0.0.0-20210701203425-01e1890a1025
 	github.com/beaker/runtime v0.0.0-20210810203340-f1025301816c
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/beaker/client v0.0.0-20210823213835-37bd0af3bc90 h1:2I/V1PdgEJhAw5GYf10Dkbh2uAGZPyUU27h480unJeY=
 github.com/beaker/client v0.0.0-20210823213835-37bd0af3bc90/go.mod h1:81i7lcaUX9ndXXvzibvBaRPIVNGJYRKyjBNFtMYrsRM=
+github.com/beaker/client v0.0.0-20210913212946-64994f6928fc h1:Law3WSdS0Sms/UgqsplLOeAEUE02jNAc3ewVALwjMRU=
+github.com/beaker/client v0.0.0-20210913212946-64994f6928fc/go.mod h1:81i7lcaUX9ndXXvzibvBaRPIVNGJYRKyjBNFtMYrsRM=
 github.com/beaker/fileheap v0.0.0-20210701203425-01e1890a1025 h1:VdlhhP4Z/k9ZXynH/3S4aCg8WrW7XocGghY0URwwLag=
 github.com/beaker/fileheap v0.0.0-20210701203425-01e1890a1025/go.mod h1:BRoXCV4r7kcKQmu/ecNvUNHoAdprT2LZvv8rnCRpI/Y=
 github.com/beaker/runtime v0.0.0-20210810203340-f1025301816c h1:s2aXRu2Nr6cytw39mTXsNTlZdovBMBMSQxLgf31F3q4=

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,6 @@ github.com/allenai/bytefmt v0.1.2/go.mod h1:3hhcDqHXjwM3JBHx4cX79jG5G3V8zKsjeutb
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/beaker/client v0.0.0-20210823213835-37bd0af3bc90 h1:2I/V1PdgEJhAw5GYf10Dkbh2uAGZPyUU27h480unJeY=
-github.com/beaker/client v0.0.0-20210823213835-37bd0af3bc90/go.mod h1:81i7lcaUX9ndXXvzibvBaRPIVNGJYRKyjBNFtMYrsRM=
 github.com/beaker/client v0.0.0-20210913212946-64994f6928fc h1:Law3WSdS0Sms/UgqsplLOeAEUE02jNAc3ewVALwjMRU=
 github.com/beaker/client v0.0.0-20210913212946-64994f6928fc/go.mod h1:81i7lcaUX9ndXXvzibvBaRPIVNGJYRKyjBNFtMYrsRM=
 github.com/beaker/fileheap v0.0.0-20210701203425-01e1890a1025 h1:VdlhhP4Z/k9ZXynH/3S4aCg8WrW7XocGghY0URwwLag=


### PR DESCRIPTION
Part of https://github.com/allenai/beaker-service/issues/1546

Adds:
 - `--save-image`/`-s` flag to `beaker session create`. If provided, the executor will commit the image once the session exits and push it to a new image in the session's workspace.
 - `beaker session images` command which gets the result images of a session.

Here's what saving an image looks like:

```
$ beaker session create --save-image
Starting session 01FF5SGZX5HA9SQYWXMYPK322A... (Press Ctrl+C to cancel)
Waiting for session to start. Done!

WARNING: The root filesystem of this session will be saved.
Do not write sensitive information outside of the home directory.

/Users/lanea $ ...

Waiting for image capture to complete... Done!
Image saved to 01FF5SHGSPS678XGBXBFZ61T3Z: https://beaker.org/im/01FF5SHGSPS678XGBXBFZ61T3Z
Resume this session with: beaker session create --image beaker://01FF5SHGSPS678XGBXBFZ61T3Z
```