### PR TITLE
Make it easy to configure a default workspace

### DIFF
--- a/cmd/beaker/config.go
+++ b/cmd/beaker/config.go
@@ -112,20 +112,6 @@ func newConfigTestCommand() *cobra.Command {
 
 			fmt.Printf("Authenticated as user: %q (%s)\n\n", user.Name, user.ID)
 
-			if cfg.DefaultOrg == "" {
-				fmt.Println("No default org set.")
-			} else {
-				fmt.Printf("Verifying default org: %q\n\n", cfg.DefaultOrg)
-				_, err := beaker.Organization(cfg.DefaultOrg).Get(ctx)
-				if err != nil {
-					fmt.Println("There was a problem verifying your default org.")
-					fmt.Println("Set the default organization in your config in the format `default_org: <org_name>`. Note that the name may be different from the name displayed in beaker UI.")
-					return err
-				}
-
-				fmt.Printf("Default org verified: %q\n", cfg.DefaultOrg)
-			}
-
 			if cfg.DefaultWorkspace == "" {
 				fmt.Println("No default workspace set.")
 			} else {

--- a/cmd/beaker/config.go
+++ b/cmd/beaker/config.go
@@ -53,8 +53,9 @@ func newConfigSetCommand() *cobra.Command {
 		Short: "Set a specific config setting",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			beakerCfg := &config.Config{}
 			configFilePath := config.GetFilePath()
-			beakerCfg, err := config.ReadConfigFromFile(configFilePath)
+			err := config.ReadConfigFromFile(configFilePath, beakerCfg)
 			if err != nil {
 				if os.IsNotExist(err) {
 					beakerCfg = beakerConfig
@@ -136,8 +137,9 @@ func newConfigUnsetCommand() *cobra.Command {
 		Short: "Unset a specific config setting",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			beakerCfg := &config.Config{}
 			configFilePath := config.GetFilePath()
-			beakerCfg, err := config.ReadConfigFromFile(configFilePath)
+			err := config.ReadConfigFromFile(configFilePath, beakerCfg)
 			if err != nil {
 				return err
 			}

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -149,7 +149,7 @@ func ensureWorkspace(workspaceRef string) (string, error) {
 				fmt.Println("The workspace will be created if it does not exist yet.")
 			} else {
 				fmt.Println("No default workspace is configured. You have no existing workspaces.")
-				fmt.Println("Enter the name of a new workspace .g. ai2/my-workspace.")
+				fmt.Println("Enter the name of a new workspace e.g. ai2/my-workspace.")
 			}
 			workspaceRef = prompt("Default workspace")
 			if i, err := strconv.Atoi(workspaceRef); err == nil {

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -132,7 +132,7 @@ func ensureWorkspace(workspaceRef string) (string, error) {
 					Author:    user.Name,
 					SortBy:    api.WorkspaceModified,
 					SortOrder: api.SortDescending,
-					Limit:     20,
+					Limit:     10,
 				})
 				if err != nil {
 					return "", err

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -145,7 +145,7 @@ func ensureWorkspace(workspaceRef string) (string, error) {
 					fmt.Printf(" %3d. %s (%d experiments)\n", i, workspace.FullName, workspace.Size.Experiments)
 				}
 
-				fmt.Println("Enter a number from the list above or the name workspace e.g. ai2/my-workspace.")
+				fmt.Println("Enter a number from the list above or the workspace name e.g. ai2/my-workspace.")
 				fmt.Println("The workspace will be created if it does not exist yet.")
 			} else {
 				fmt.Println("No default workspace is configured. You have no existing workspaces.")

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ func ReadConfigFromFile(path string, config *Config) error {
 	defer r.Close()
 
 	d := yaml.NewDecoder(r)
-	if err := d.Decode(config); err != nil {
+	if err := d.Decode(config); err != nil && err != io.EOF {
 		return errors.Wrap(err, "failed to read config")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	// Client settings
 	BeakerAddress    string `yaml:"agent_address"` // TODO: Find a better name than "agent_address"
 	UserToken        string `yaml:"user_token"`
-	DefaultOrg       string `yaml:"default_org"`
 	DefaultWorkspace string `yaml:"default_workspace"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,16 +35,9 @@ func New() (*Config, error) {
 		BeakerAddress: defaultAddress,
 	}
 
-	r, err := findConfig()
+	err := ReadConfigFromFile(GetFilePath(), &config)
 	if err != nil {
 		return nil, err
-	}
-	if r != nil {
-		defer r.Close()
-
-		if err := yaml.NewDecoder(r).Decode(&config); err != nil {
-			return nil, errors.Wrap(err, "failed to read config")
-		}
 	}
 
 	// Environment variables override config.
@@ -70,20 +62,19 @@ func GetFilePath() string {
 	return filepath.Join(beakerConfigDir, beakerConfigFile)
 }
 
-func ReadConfigFromFile(path string) (*Config, error) {
+func ReadConfigFromFile(path string, config *Config) error {
 	r, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer r.Close()
 
-	config := Config{}
 	d := yaml.NewDecoder(r)
-	if err := d.Decode(&config); err != nil {
-		return nil, errors.Wrap(err, "failed to read config")
+	if err := d.Decode(config); err != nil {
+		return errors.Wrap(err, "failed to read config")
 	}
 
-	return &config, nil
+	return nil
 }
 
 func WriteConfig(config *Config, filePath string) error {
@@ -98,30 +89,4 @@ func WriteConfig(config *Config, filePath string) error {
 	}
 
 	return ioutil.WriteFile(filePath, bytes, 0644)
-}
-
-func findConfig() (io.ReadCloser, error) {
-	// Check the path override first.
-	if env, ok := os.LookupEnv(configPathKey); ok {
-		return os.Open(env)
-	}
-	if env, ok := os.LookupEnv(configPathKeyLegacy); ok {
-		return os.Open(env)
-	}
-
-	configPaths := []string{
-		beakerConfigDir,
-		"/etc/beaker",
-	}
-
-	for _, p := range configPaths {
-		r, err := os.Open(filepath.Join(p, beakerConfigFile))
-		if os.IsNotExist(err) {
-			continue
-		}
-		return r, errors.WithStack(err)
-	}
-
-	// No config file found; we'll just use defaults.
-	return nil, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/allenai/bytefmt v0.1.2
-	github.com/beaker/client v0.0.0-20211213171028-d71be4677425
+	github.com/beaker/client v0.0.0-20220118174312-992c493d18d8
 	github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320
 	github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/allenai/bytefmt v0.1.2 h1:27970/ph1eYlv9e5i6Jc6SZoIyXy+DVD4hDDiF0dQGI
 github.com/allenai/bytefmt v0.1.2/go.mod h1:3hhcDqHXjwM3JBHx4cX79jG5G3V8zKsjeutbhJ3XjI0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/beaker/client v0.0.0-20211213171028-d71be4677425 h1:wZO7n9m239dyE1MNX8t9JthFZ431m/U562vkWmpNa5k=
-github.com/beaker/client v0.0.0-20211213171028-d71be4677425/go.mod h1:gneEdoTEWgYoS32NWMZN6bsZWqlnYSj3NxFawTTJPWI=
+github.com/beaker/client v0.0.0-20220118174312-992c493d18d8 h1:rDcZ19MPKf20umUkBeQV5hw3R8q7UIK/aOIz2V0nvew=
+github.com/beaker/client v0.0.0-20220118174312-992c493d18d8/go.mod h1:gneEdoTEWgYoS32NWMZN6bsZWqlnYSj3NxFawTTJPWI=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320 h1:z3Ed6zWWi5wz+AUojzbxZglrfNLM8YeeMrmAv7WbsQQ=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320/go.mod h1:B39KYPwS7QX1cXqPUKmC0ypuZy5idMGwPsLrY1N7dWQ=
 github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad h1:m6VFGPVTfwKAxjRakGf5tc9vy5e5SPVbRNfTpvEmPxY=


### PR DESCRIPTION
Fixes https://github.com/allenai/beaker-service/issues/1728

If a user doesn't have a default workspace configured, they will get a nice prompt like this:

```
No default workspace is configured. Please select one of your workspaces:
   0. ai2/lane-test-workspace (0 experiments)
   1. ai2/lane (30 experiments)
   2. ai2/lanea (72 experiments)
Enter a number from the list above or the name workspace e.g. ai2/my-workspace.
The workspace will be created if it does not exist yet.
Default workspace: 1
Setting default workspace to ai2/lane
```

If they don't have any workspaces yet it looks like this:

```
No default workspace is configured. You have no existing workspaces.
Enter the name of a new workspace e.g. ai2/my-workspace.
The workspace will be created if it does not exist yet.
Default workspace: ai2/my-new-workspace
Setting default workspace to ai2/my-new-workspace
```