### PR TITLE
fix job list 

### DIFF
--- a/cmd/beaker/job.go
+++ b/cmd/beaker/job.go
@@ -169,13 +169,25 @@ func newJobListCommand() *cobra.Command {
 			kind := api.JobKind(kind)
 			opts.Kind = &kind
 		}
-		if node == "" && cluster == "" && len(experiments) == 0 {
-			var err error
-			if node, err = getCurrentNode(); err != nil {
-				return fmt.Errorf("failed to detect node; use --node flag: %w", err)
+
+		if node == "" {
+			if cluster == "" && len(experiments) == 0 {
+				var err error
+				if node, err = getCurrentNode(); err != nil {
+					return fmt.Errorf("failed to detect node; use --node flag: %w", err)
+				}
+				opts.Node = &node
+			}
+		} else { // some node is specified
+			if cluster != "" {
+				return fmt.Errorf("you cannot specify node and cluster")
+			}
+			if len(experiments) > 0 {
+				return fmt.Errorf("you cannot specify node and experiments")
 			}
 			opts.Node = &node
 		}
+
 		if len(experiments) > 0 {
 			opts.Experiments = experiments
 		}

--- a/cmd/beaker/main.go
+++ b/cmd/beaker/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/allenai/beaker/config"
 	"github.com/beaker/client/api"
@@ -68,6 +69,16 @@ func main() {
 				beakerConfig.BeakerAddress,
 				beakerConfig.UserToken,
 			)
+			if beakerConfig.HTTPDiag {
+				beaker.HTTPResponseHook = func(resp *http.Response, duration time.Duration) {
+					durationMs := duration.Nanoseconds() / 1000000
+					fmt.Fprintf(os.Stderr,
+						"Beaker HTTP diagnostic: status_code = %d duration_ms = %d request = %s %s\n",
+						resp.StatusCode, durationMs, resp.Request.Method, resp.Request.URL.String(),
+					)
+				}
+			}
+
 			return err
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	UserToken        string `yaml:"user_token,omitempty"`
 	DefaultWorkspace string `yaml:"default_workspace,omitempty"`
 	DefaultImage     string `yaml:"default_image,omitempty"`
+	HTTPDiag         bool   `yaml:"http_diag,omitempty"`
 }
 
 const (
@@ -24,6 +25,7 @@ const (
 	configPathKey       = "BEAKER_CONFIG"
 	configPathKeyLegacy = "BEAKER_CONFIG_FILE" // TODO: Remove when we're sure it's unused.
 	tokenKey            = "BEAKER_TOKEN"
+	httpDiagKey         = "BEAKER_HTTP_DIAG"
 	defaultAddress      = "https://beaker.org"
 	beakerConfigFile    = "config.yml"
 )
@@ -48,6 +50,9 @@ func New() (*Config, error) {
 	}
 	if env, ok := os.LookupEnv(tokenKey); ok {
 		config.UserToken = env
+	}
+	if env, ok := os.LookupEnv(httpDiagKey); ok {
+		config.HTTPDiag = env == "true"
 	}
 
 	return &config, nil


### PR DESCRIPTION
I've added an HTTP diagnostics setting (env var BEAKER_HTTP_DIAG set to `true`, or config setting http_diag set to true).

Using it, I see that before this change, listing listing jobs on a specific node did not include the node in the request:

```
$ BEAKER_HTTP_DIAG=true BEAKER_CONFIG_FILE=/Users/michalg/.beaker/config-dev.yml ./beaker job list --node 01FST4XHNQR5H9DFJ38VB55MVQ
Beaker HTTP diagnostic: status_code = 200 duration_ms = 411 request = GET https://dev.beaker.org/api/v3/jobs?finalized=false
ID                          KIND       NAME          AUTHOR       STATUS   SCHEDULED  DURATION  GPUS  NODE
01EG6CHV4QT04VM6F98Z3VG06T  execution  echo          ckarenz      pending  N/A        00:00:00  N/A   N/A
01EQM8TCSER8AYCS6W343CQXQQ  execution  nvidia-smi    michaels     pending  N/A        00:00:00  N/A   N/A
01FHBHCT6Z0Y9Z96WBBEYWDX0G  execution  copy-things   michalg      pending  N/A        00:00:00  N/A   N/A
01FK6F8BS5RTQFSP1NCM254RDW  execution  docker-image  healthcheck  pending  N/A        00:00:00  N/A   N/A
01FK6F8NH8687XRVR10ZKP755X  execution  cp            healthcheck  pending  N/A        00:00:00  N/A   N/A
01FK6F8NNX72R1GWDJT8AMG2S2  execution  beaker-image  healthcheck  pending  N/A        00:00:00  N/A   N/A
01FK6F8NSZEA9175ZFX4YR553E  execution  secret-env    healthcheck  pending  N/A        00:00:00  N/A   N/A
01FK6F8NYNP996W602K7Q3HM1B  execution  secret-file   healthcheck  pending  N/A        00:00:00  N/A   N/A
01FK6F8P3DP6F9H9NM7W8K6C8F  execution  docker-image  healthcheck  pending  N/A        00:00:00  N/A   N/A
```

And after this change, the node is included in the request, returning no jobs (as I'd expect):

```
$ BEAKER_HTTP_DIAG=true BEAKER_CONFIG_FILE=/Users/michalg/.beaker/config-dev.yml ./beaker job list --node 01FST4XHNQR5H9DFJ38VB55MVQ
Beaker HTTP diagnostic: status_code = 200 duration_ms = 440 request = GET https://dev.beaker.org/api/v3/jobs?finalized=false&node=01FST4XHNQR5H9DFJ38VB55MVQ
ID  KIND  NAME  AUTHOR  STATUS  SCHEDULED  DURATION  GPUS  NODE
```
