### PR TITLE
Fix the configure command.

### DIFF
--- a/cmd/beaker/executor.go
+++ b/cmd/beaker/executor.go
@@ -13,6 +13,9 @@ const (
 	// Location for storing Beaker configuration.
 	executorConfigDir = "/etc/beaker"
 
+	// Location of Beaker runtime artifacts (datasets, node information, etc)
+	executorStoragePath = "/var/beaker"
+
 	// Path to the node file within the executor's storage directory.
 	executorNodePath = "node"
 )

--- a/cmd/beaker/executor_linux.go
+++ b/cmd/beaker/executor_linux.go
@@ -39,6 +39,7 @@ var (
 )
 
 var configTemplate = template.Must(template.New("config").Parse(`
+storagePath: {{.StoragePath}}
 beaker:
   address: {{.Address}}
   tokenPath: {{.TokenPath}}
@@ -47,10 +48,11 @@ resources:
   gpus: {{.GPUs}}`))
 
 type configOpts struct {
-	Address   string
-	TokenPath string
-	Cluster   string
-	GPUs      string
+	StoragePath string
+	Address     string
+	TokenPath   string
+	Cluster     string
+	GPUs        string
 }
 
 var systemdTemplate = template.Must(template.New("systemd").Parse(`
@@ -113,6 +115,10 @@ func newExecutorConfigureCommand() *cobra.Command {
 			return err
 		}
 
+		if err := os.MkdirAll(executorStoragePath, os.ModePerm); err != nil {
+			return err
+		}
+
 		if err := ioutil.WriteFile(
 			executorTokenPath,
 			[]byte(beakerConfig.UserToken),
@@ -132,10 +138,11 @@ func newExecutorConfigureCommand() *cobra.Command {
 		}
 		defer configFile.Close()
 		return configTemplate.Execute(configFile, configOpts{
-			Address:   beakerConfig.BeakerAddress,
-			TokenPath: executorTokenPath,
-			Cluster:   cluster,
-			GPUs:      gpus,
+			StoragePath: executorStoragePath,
+			Address:     beakerConfig.BeakerAddress,
+			TokenPath:   executorTokenPath,
+			Cluster:     cluster,
+			GPUs:        gpus,
 		})
 	}
 	return cmd


### PR DESCRIPTION
I tried walking through the self hosting instructions, but ran into a bug. The
executor wouldn't start because of an error at at startup:

```
error: getting storage path: $HOME is not defined
```

That error originates from [this code](https://github.com/allenai/beaker-service/blob/5a9afb877321519943eb2f2d1446b9f4c367c1a8/cmd/executor/main.go#L122-L125),
which is executed as the executor starts up.

The error occurs because we try to use the process owner's [home directory](https://github.com/allenai/beaker-service/blob/5a9afb877321519943eb2f2d1446b9f4c367c1a8/cmd/executor/main.go#L48)
as a default, but because the process is ran non-interactively, `$HOME` isn't set.

This fixes that by explicitly setting the storage path to `/var/beaker`, and
by making sure that directory exists.

Alternatively we could change the default, though that'll require updating that
default in multiple places, as we currently have code in both the CLI and the executor
for doing so.

https://github.com/allenai/beaker-service/issues/1968