### PR TITLE
Add flag for exposing session ports.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/allenai/bytefmt v0.1.2
-	github.com/beaker/client v0.0.0-20220118174312-992c493d18d8
+	github.com/beaker/client v0.0.0-20220421175640-599703769000
 	github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320
 	github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad
 	github.com/docker/distribution v2.8.1+incompatible
@@ -33,6 +33,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
@@ -54,7 +55,6 @@ require (
 	google.golang.org/genproto v0.0.0-20220208230804-65c12eb4c068 // indirect
 	google.golang.org/grpc v1.44.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
 // See https://github.com/advisories/GHSA-c2h3-6mxw-7mvq

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/allenai/bytefmt v0.1.2 h1:27970/ph1eYlv9e5i6Jc6SZoIyXy+DVD4hDDiF0dQGI
 github.com/allenai/bytefmt v0.1.2/go.mod h1:3hhcDqHXjwM3JBHx4cX79jG5G3V8zKsjeutbhJ3XjI0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/beaker/client v0.0.0-20220118174312-992c493d18d8 h1:rDcZ19MPKf20umUkBeQV5hw3R8q7UIK/aOIz2V0nvew=
-github.com/beaker/client v0.0.0-20220118174312-992c493d18d8/go.mod h1:gneEdoTEWgYoS32NWMZN6bsZWqlnYSj3NxFawTTJPWI=
+github.com/beaker/client v0.0.0-20220421175640-599703769000 h1:+q57+NHrNvNBscKC5TxKY/rcZRqGzVhj32VdqrtRUIg=
+github.com/beaker/client v0.0.0-20220421175640-599703769000/go.mod h1:3YTEVm+/Yb/iPCh9tq0PzotY/DTdEYoEO6WvU882XJU=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320 h1:z3Ed6zWWi5wz+AUojzbxZglrfNLM8YeeMrmAv7WbsQQ=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320/go.mod h1:B39KYPwS7QX1cXqPUKmC0ypuZy5idMGwPsLrY1N7dWQ=
 github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad h1:m6VFGPVTfwKAxjRakGf5tc9vy5e5SPVbRNfTpvEmPxY=


### PR DESCRIPTION
This adds the `--port` flag to the `beaker session create`
command.

This codebase doesn't have any tests. So I tested manually.  I started
a local executor, then build a local `beaker` CLI and started a session
like so:

```
❯ ./beaker session create \
        --node 01G16Y53QY0YYNYPDNRYJ1A36T \
        --image beaker://sams/cuda11.2-ubuntu20.04 \
        --port 8888
```

This worked! The `docker ps` command shows the container, with a random port
bound to container port `8888`:

```
❯ docker ps
CONTAINER ID   IMAGE                                                     COMMAND     CREATED          STATUS          PORTS                     NAMES
0a63319a448d   gcr.io/ai2-beaker-core/uploads/dev/c7g9tvj56ghj02m8t4g0   "bash -l"   27 seconds ago   Up 25 seconds   0.0.0.0:55106->8888/tcp   session-01g16zmjee54a35xm9s5f7snkn
```

I tested invalid ports (overflow, 0, etc). Everything seemed to work.

https://github.com/allenai/beaker-service/issues/2009
