### PR TITLE
Print exposed ports on session start.

### DIFF
--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -274,6 +274,23 @@ Do not write sensitive information outside of the home directory.
 `))
 		}
 
+		info, err := container.Info(ctx)
+		if err != nil {
+			return fmt.Errorf("getting container info: %w", err)
+		}
+
+		if len(info.TCPPorts) > 0 {
+			bindings := []string{}
+			for _, pb := range info.TCPPorts {
+				bindings = append(bindings, color.BlueString(
+					"0.0.0.0:%d->%d/tcp",
+					pb.HostPort,
+					pb.ContainerPort,
+				))
+			}
+			fmt.Printf("Exposed Ports: %s\n", strings.Join(bindings, ", "))
+		}
+
 		if err := handleAttachErr(container.Stream(ctx, resp)); err != nil {
 			return fmt.Errorf("stream: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/allenai/bytefmt v0.1.2
 	github.com/beaker/client v0.0.0-20220421175640-599703769000
 	github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320
-	github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad
+	github.com/beaker/runtime v0.0.0-20220421165624-9a027d1b3070
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/fatih/color v1.13.0
@@ -47,14 +47,14 @@ require (
 	github.com/vbauerster/mpb/v4 v4.12.2 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/net v0.0.0-20220420153159-1850ba15e1be // indirect
 	golang.org/x/sys v0.0.0-20220207234003-57398862261d // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220208230804-65c12eb4c068 // indirect
 	google.golang.org/grpc v1.44.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 )
 
 // See https://github.com/advisories/GHSA-c2h3-6mxw-7mvq

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/beaker/client v0.0.0-20220421175640-599703769000 h1:+q57+NHrNvNBscKC5
 github.com/beaker/client v0.0.0-20220421175640-599703769000/go.mod h1:3YTEVm+/Yb/iPCh9tq0PzotY/DTdEYoEO6WvU882XJU=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320 h1:z3Ed6zWWi5wz+AUojzbxZglrfNLM8YeeMrmAv7WbsQQ=
 github.com/beaker/fileheap v0.0.0-20211007204440-1bd3920c4320/go.mod h1:B39KYPwS7QX1cXqPUKmC0ypuZy5idMGwPsLrY1N7dWQ=
-github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad h1:m6VFGPVTfwKAxjRakGf5tc9vy5e5SPVbRNfTpvEmPxY=
-github.com/beaker/runtime v0.0.0-20211213171103-95151aa06fad/go.mod h1:kq19c3LwPFCDkO+EzV4SabGXxIWB05mGoIjlv4pTLH8=
+github.com/beaker/runtime v0.0.0-20220421165624-9a027d1b3070 h1:48/x2O5YQ0OQUuaPIzHBGAJvx3BHanXFPI8WEBdqufc=
+github.com/beaker/runtime v0.0.0-20220421165624-9a027d1b3070/go.mod h1:LakRnDa331rwK+j5BzdNbgiQfX5Rguc6erUherUj6cY=
 github.com/beaker/unique v0.0.0-20210625205350-416101674f78 h1:2DGuDNo5vvNThxIN8SOh/iJit+W8Za0+uo/XEts6pWM=
 github.com/beaker/unique v0.0.0-20210625205350-416101674f78/go.mod h1:ezC2AFSqZalISBiS5Ldrbj2YQ83rmztQX6YGPv7Cd2A=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -802,8 +802,9 @@ golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220420153159-1850ba15e1be h1:yx80W7nvY5ySWpaU8UWaj5o9e23YgO9BRhQol7Lc+JI=
+golang.org/x/net v0.0.0-20220420153159-1850ba15e1be/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -924,7 +925,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211209171907-798191bca915/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1169,8 +1169,9 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1230,7 +1231,6 @@ k8s.io/code-generator v0.19.7/go.mod h1:lwEq3YnLYb/7uVXLorOJfxg+cUu2oihFhHZ0n9NI
 k8s.io/component-base v0.20.6/go.mod h1:6f1MPBAeI+mvuts3sIdtpjljHWBQ2cIy38oBIWMYnrM=
 k8s.io/component-base v0.22.5/go.mod h1:VK3I+TjuF9eaa+Ln67dKxhGar5ynVbwnGrUiNF4MqCI=
 k8s.io/cri-api v0.20.6/go.mod h1:ew44AjNXwyn1s0U4xCKGodU7J1HzBeZ1MpGrpa5r8Yc=
-k8s.io/cri-api v0.23.0/go.mod h1:2edENu3/mkyW3c6fVPPPaVGEFbLRacJizBbSp7ZOLOo=
 k8s.io/cri-api v0.23.1/go.mod h1:REJE3PSU0h/LOV1APBrupxrEJqnoxZC8KWzkBUHwrK4=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=


### PR DESCRIPTION
This adds code for printing the exposed ports when the container
starts.

It looks like so:

```
❯ ./beaker session create --port 8888 --port 8889
Defaulting to workspace org/name
Starting session ZZZ... (Press Ctrl+C to cancel)
Waiting for session to start.. Done!
Exposed Ports: 0.0.0.0:55117->8888/tcp, 0.0.0.0:55116->8889/tcp
[beaker] sams ~ $
```

I'll add this to other commands, like `beaker session get` too in
the near future.