### PR TITLE
Add command for showing detailed session information.

### DIFF
--- a/cmd/beaker/print.go
+++ b/cmd/beaker/print.go
@@ -232,6 +232,18 @@ func printImages(images []api.Image) error {
 	}
 }
 
+func jobDuration(job api.Job) time.Duration {
+	var duration time.Duration
+	if job.Status.Scheduled != nil {
+		end := time.Now()
+		if job.Status.Finalized != nil {
+			end = *job.Status.Finalized
+		}
+		duration = end.Sub(*job.Status.Scheduled)
+	}
+	return duration
+}
+
 func printJobs(jobs []api.Job) error {
 	switch format {
 	case formatJSON:
@@ -251,14 +263,7 @@ func printJobs(jobs []api.Job) error {
 			return err
 		}
 		for _, job := range jobs {
-			var duration time.Duration
-			if job.Status.Scheduled != nil {
-				end := time.Now()
-				if job.Status.Finalized != nil {
-					end = *job.Status.Finalized
-				}
-				duration = end.Sub(*job.Status.Scheduled)
-			}
+			duration := jobDuration(job)
 
 			var scheduled time.Time
 			if job.Status.Scheduled != nil {

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -573,7 +573,7 @@ func newSessionDescribeCommand() *cobra.Command {
 					}
 					url := fmt.Sprintf("http://%s:%d", node.Hostname, pb.HostPort)
 					p := fmt.Sprintf(
-						"%s:%d->%d/tcp (%s)",
+						"%s:%d->%d/tcp (e.g., %s)",
 						node.Hostname,
 						pb.HostPort,
 						pb.ContainerPort,

--- a/cmd/beaker/session.go
+++ b/cmd/beaker/session.go
@@ -520,7 +520,7 @@ func newSessionDescribeCommand() *cobra.Command {
 				printJSON(details)
 			default:
 				printTableRow("ID", details.ID)
-				printTableRow("Name", details.Name)
+				printTableRow("NAME", details.Name)
 				printTableRow(
 					"User",
 					fmt.Sprintf(
@@ -536,7 +536,7 @@ func newSessionDescribeCommand() *cobra.Command {
 				} else if details.Session.Image.Docker != "" {
 					img = fmt.Sprintf("docker://%s", details.Session.Image.Docker)
 				}
-				printTableRow("Image", img)
+				printTableRow("IMAGE", img)
 
 				// Print some extra information for Beaker images, since we have it.
 				if details.Session.Image.Beaker != "" {
@@ -554,9 +554,9 @@ func newSessionDescribeCommand() *cobra.Command {
 				if details.Status.Scheduled != nil {
 					start = *details.Status.Scheduled
 				}
-				printTableRow("Started", start)
-				printTableRow("Elapsed", jobDuration(*details.Job))
-				printTableRow("Status", jobStatus(details.Job.Status))
+				printTableRow("STARTED", start)
+				printTableRow("ELAPSED", jobDuration(*details.Job))
+				printTableRow("STATUS", jobStatus(details.Job.Status))
 
 				var gpus string
 				if details.Limits != nil {
@@ -569,7 +569,7 @@ func newSessionDescribeCommand() *cobra.Command {
 					// which we don't want, so we pass a single space instead.
 					title := " "
 					if i == 0 {
-						title = "TCP Ports"
+						title = "TCP PORTS"
 					}
 					url := fmt.Sprintf("http://%s:%d", node.Hostname, pb.HostPort)
 					p := fmt.Sprintf(


### PR DESCRIPTION
This PR adds the `beaker session describe` command, which
prints detailed information about a running session.

As part of this I decided to delete the `inspect` alias for
`beaker session get`. I figured it's probably not used, and
confusing if `inspect` doesn't do what `describe` does now.

The describe output looks like so as text:

```
❯ ./beaker session describe ZZZ
ID         ZZZ
Name       N/A
User       Sam "Skjonsie" Skjons🍔 (sams)
Image      beaker://sams/cuda11.2-ubuntu20.04
           https://dev.beaker.org/im/YYY
Started    2022-04-22 14:35:57
Elapsed    00:16:14
Status     running
GPUS       N/A
TCP Ports  sams.macbook:55125->8888/tcp (http://sams.macbook:55125)
           sams.macbook:55124->8889/tcp (http://sams.macbook:55124)
```

...and like so as JSON:

```
❯ ./beaker session describe ZZZ --format json
{
    "kind": "session",
    "id": "ZZZ",
    "author": {
        "id": "YYY",
        "name": "sams",
        "displayName": "Sam \"Skjonsie\" Skjons🍔"
    },
    "workspace": "WWW",
    "cluster": "CCC",
    "node": "NNN",
    "status": {
        "created": "2022-04-22T21:35:56.041487Z",
        "scheduled": "2022-04-22T21:35:57.863943Z",
        "started": "2022-04-22T21:35:58.515615Z",
        "idleSince": "2022-04-22T21:36:01.5849Z"
    },
    "session": {
        "image": {
            "beaker": "sams/cuda11.2-ubuntu20.04"
        },
        "ports": [
            8888,
            8889
        ]
    },
    "runtime": {
        "tcp_ports": [
            {
                "host_port": 55125,
                "container_port": 8888
            },
            {
                "host_port": 55124,
                "container_port": 8889
            }
        ]
    }
}
```

https://github.com/allenai/beaker-service/issues/2011